### PR TITLE
Support `initialValue` in text prompt

### DIFF
--- a/.changeset/lazy-mirrors-kick.md
+++ b/.changeset/lazy-mirrors-kick.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": patch
+"@clack/core": patch
+---
+
+Support `initialValue` option for text prompt

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -22,7 +22,7 @@ async function main() {
 
   const dir = await text({
     message: "Where should we create your project?",
-    placeholder: "./sparkling-slop",
+    placeholder: "./sparkling-solid",
   });
 
   if (isCancel(dir)) {
@@ -61,6 +61,7 @@ async function main() {
 
   const install = await confirm({
     message: "Install dependencies?",
+    initialValue: false
   });
 
   if (isCancel(install)) {
@@ -79,7 +80,7 @@ async function main() {
 
   note(nextSteps, 'Next steps.');
   
-  await setTimeout(3000);
+  await setTimeout(1000);
 
   outro(`Problems? ${color.underline(color.cyan('https://example.com/issues'))}`);
 }

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -56,7 +56,7 @@ export default class Prompt {
   public value: any;
   public error: string = '';
 
-  constructor({ render, input = stdin, output = stdout, initialValue, ...opts }: PromptOptions<Prompt>, trackValue: boolean = true) {
+  constructor({ render, input = stdin, output = stdout, ...opts }: PromptOptions<Prompt>, trackValue: boolean = true) {
     this.opts = opts;
     this.onKeypress = this.onKeypress.bind(this);
     this.close = this.close.bind(this);
@@ -89,6 +89,9 @@ export default class Prompt {
     })
     readline.emitKeypressEvents(this.input, this.rl);
     this.rl.prompt();
+    if (this.opts.initialValue !== undefined && this._track) {
+      this.rl.write(this.opts.initialValue);
+    }
 
     this.input.on('keypress', this.onKeypress);
     setRawMode(this.input, true);

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -54,6 +54,7 @@ import { text } from "@clack/prompts";
 const meaning = await text({
   message: "What is the meaning of life?",
   placeholder: "Not sure",
+  initialValue: "42",
   validate(value) {
     if (value.length === 0) return `Value is required!`;
   },

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -27,12 +27,14 @@ const barEnd = "└";
 export interface TextOptions {
   message: string;
   placeholder?: string;
+  initialValue?: string;
   validate?: (value: string) => string | void;
 }
 export const text = (opts: TextOptions) => {
   return new TextPrompt({
     validate: opts.validate,
     placeholder: opts.placeholder,
+    initialValue: opts.initialValue,
     render() {
       const title = `${color.gray(bar)}\n${symbol(this.state)}  ${
         opts.message


### PR DESCRIPTION
Closes #26. Closes #27.

There was an existing `initialValue` option, it just wasn't wired up properly for the `text` component. Now it is!