### PR TITLE
chore: vendor ansi-regex

### DIFF
--- a/.changeset/cyan-onions-help.md
+++ b/.changeset/cyan-onions-help.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fix CJS `ansi-regex` interop

--- a/packages/prompts/LICENSE
+++ b/packages/prompts/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+`ansi-regex` is adapted from https://github.com/chalk/ansi-regex
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -53,7 +53,6 @@
   },
   "dependencies": {
     "@clack/core": "workspace:^0.1.3",
-    "ansi-regex": "^6.0.1",
     "picocolors": "^1.0.0",
     "sisteransi": "^1.0.5"
   },

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -2,8 +2,6 @@ import { State } from "@clack/core";
 import { MultiSelectPrompt, TextPrompt, SelectPrompt, ConfirmPrompt, block } from "@clack/core";
 import color from "picocolors";
 import { cursor, erase } from "sisteransi";
-import ansiRegex from 'ansi-regex';
-
 export { isCancel } from "@clack/core";
 
 const symbol = (state: State) => {
@@ -297,3 +295,14 @@ export const spinner = () => {
     },
   };
 };
+
+// Adapted from https://github.com/chalk/ansi-regex
+// @see LICENSE
+function ansiRegex() {
+	const pattern = [
+		'[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+		'(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
+	].join('|');
+
+	return new RegExp(pattern, 'g');
+}


### PR DESCRIPTION
Closes #31

Vendors `ansi-regex` from https://github.com/chalk/ansi-regex, licensed under the MIT license. Updates LICENSE information for `@clack/prompts`