### PR TITLE
fix: multiple select initialValue incorrect logic

### DIFF
--- a/.changeset/little-papayas-watch.md
+++ b/.changeset/little-papayas-watch.md
@@ -1,0 +1,6 @@
+---
+"@clack/core": patch
+"@clack/prompts": patch
+---
+
+Fix multiselect initial value logic

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -37,6 +37,7 @@ async function main() {
       { value: "js", label: "JavaScript" },
       { value: "coffee", label: "CoffeeScript", hint: "oh no" },
     ],
+    initialValue: 'ts'
   });
 
   if (isCancel(projectType)) {
@@ -52,6 +53,8 @@ async function main() {
       { value: "stylelint", label: "Stylelint" },
       { value: "gh-action", label: "GitHub Action" },
     ],
+    initialValue: ['eslint', 'gh-action'],
+    cursorAt: 'stylelint'
   });
 
   if (isCancel(tools)) {

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -3,7 +3,8 @@ import color from 'picocolors';
 
 interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
     options: T[];
-    initialValue?: T['value'];
+    initialValue?: T['value'][];
+    cursorAt?: T['value']
 }
 export default class MultiSelectPrompt<T extends { value: any }> extends Prompt {
     options: T[];
@@ -34,8 +35,8 @@ export default class MultiSelectPrompt<T extends { value: any }> extends Prompt 
             this.value = this.selectedValues;
         })
         this.options = opts.options;
-        this.cursor = this.options.findIndex(({ value }) => value === opts.initialValue);
-        this.selectedValues = []
+        this.cursor = this.options.findIndex(({ value }) => value === opts.cursorAt);
+        this.selectedValues = opts.initialValue || [];
         if (this.cursor === -1) this.cursor = 0;
 
         this.on('cursor', (key) => {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -115,6 +115,14 @@ export interface SelectOptions<Options extends Option<Value>[], Value extends Re
   options: Options;
   initialValue?: Options[number]["value"];
 }
+
+export interface MultiSelectOptions<Options extends Option<Value>[], Value extends Readonly<string>> {
+  message: string;
+  options: Options;
+  initialValue?: Options[number]['value'][];
+  cursorAt?: Options[number]["value"]
+}
+
 export const select = <Options extends Option<Value>[], Value extends Readonly<string>>(
   opts: SelectOptions<Options, Value>
 ) => {
@@ -166,7 +174,7 @@ export const select = <Options extends Option<Value>[], Value extends Readonly<s
   }).prompt() as Promise<Options[number]['value'] | symbol>;
 };
 
-export const multiselect = <Options extends Option<Value>[], Value extends Readonly<string>>(opts: SelectOptions<Options, Value>) => {
+export const multiselect = <Options extends Option<Value>[], Value extends Readonly<string>>(opts: MultiSelectOptions<Options, Value>) => {
     const opt = (option: Options[number], state: 'inactive' | 'active' | 'selected' | 'active-selected' | 'submitted' | 'cancelled') => {
         const label =  option.label ?? option.value;
         if (state === 'active') {
@@ -186,6 +194,7 @@ export const multiselect = <Options extends Option<Value>[], Value extends Reado
     return new MultiSelectPrompt({
         options: opts.options,
         initialValue: opts.initialValue,
+        cursorAt: opts.cursorAt,
         render() {
             let title = `${color.gray(bar)}\n${symbol(this.state)}  ${opts.message}\n`;
 


### PR DESCRIPTION
`initialValue` should set to `selectedValue`, not be the place that cursor at.

I created a new property `cursorAt` to cover the old logic.

Before:

<img width="618" alt="image" src="https://user-images.githubusercontent.com/49969959/218917393-f456a133-4ed6-4e7a-8090-b015cf1d47fc.png">

After:

<img width="602" alt="image" src="https://user-images.githubusercontent.com/49969959/218917498-34fd31f0-827c-4d91-88be-02591c9bc8e1.png">


