### PR TITLE
Support `isAllowEmpty` in multi-select prompt

### DIFF
--- a/.changeset/heavy-fishes-change.md
+++ b/.changeset/heavy-fishes-change.md
@@ -3,4 +3,4 @@
 "@clack/core": patch
 ---
 
-Support `isAllowEmpty` option for multi-select
+Support `required` option for multi-select

--- a/.changeset/heavy-fishes-change.md
+++ b/.changeset/heavy-fishes-change.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": patch
+"@clack/core": patch
+---
+
+Support `isAllowEmpty` option for multi-select

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -4,7 +4,7 @@ import color from 'picocolors';
 interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
     options: T[];
     initialValue?: T['value'];
-    isAllowEmpty?: boolean
+    required?: boolean
 }
 export default class MultiSelectPrompt<T extends { value: any }> extends Prompt {
     options: T[];

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -28,7 +28,7 @@ export default class MultiSelectPrompt<T extends { value: any }> extends Prompt 
     constructor(opts: MultiSelectOptions<T>) {
         if (!opts.validate) {
             opts.validate = () => {
-                if (!opts.isAllowEmpty && this.selectedValues.length === 0) return `Please select at least one option\n${color.reset(color.dim(`Press ${color.gray(color.bgWhite(color.inverse(' space ')))} to select, ${color.gray(color.bgWhite(color.inverse(' enter ')))} to submit`))}`
+                if (opts.required && this.selectedValues.length === 0) return `Please select at least one option\n${color.reset(color.dim(`Press ${color.gray(color.bgWhite(color.inverse(' space ')))} to select, ${color.gray(color.bgWhite(color.inverse(' enter ')))} to submit`))}`
             }
         }
         super(opts, false);

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -4,6 +4,7 @@ import color from 'picocolors';
 interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
     options: T[];
     initialValue?: T['value'];
+    isAllowEmpty?: boolean
 }
 export default class MultiSelectPrompt<T extends { value: any }> extends Prompt {
     options: T[];
@@ -26,7 +27,7 @@ export default class MultiSelectPrompt<T extends { value: any }> extends Prompt 
     constructor(opts: MultiSelectOptions<T>) {
         if (!opts.validate) {
             opts.validate = () => {
-                if (this.selectedValues.length === 0) return `Please select at least one option\n${color.reset(color.dim(`Press ${color.gray(color.bgWhite(color.inverse(' space ')))} to select, ${color.gray(color.bgWhite(color.inverse(' enter ')))} to submit`))}`
+                if (!opts.isAllowEmpty && this.selectedValues.length === 0) return `Please select at least one option\n${color.reset(color.dim(`Press ${color.gray(color.bgWhite(color.inverse(' space ')))} to select, ${color.gray(color.bgWhite(color.inverse(' enter ')))} to submit`))}`
             }
         }
         super(opts, false);

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -104,6 +104,7 @@ const additionalTools = await multiselect({
     { value: "prettier", label: "Prettier" },
     { value: "gh-action", label: "GitHub Action" },
   ],
+  isAllowEmpty: true,
 });
 ```
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -104,7 +104,7 @@ const additionalTools = await multiselect({
     { value: "prettier", label: "Prettier" },
     { value: "gh-action", label: "GitHub Action" },
   ],
-  isAllowEmpty: true,
+  required: false,
 });
 ```
 

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -135,13 +135,13 @@ export interface SelectOptions<Options extends Option<Value>[], Value extends Pr
   message: string;
   options: Options;
   initialValue?: Options[number]["value"];
-  isAllowEmpty?: boolean;
 }
 
 export interface MultiSelectOptions<Options extends Option<Value>[], Value extends Primitive> {
   message: string;
   options: Options;
   initialValue?: Options[number]['value'][];
+  required?: boolean;
   cursorAt?: Options[number]["value"]
 }
 
@@ -216,7 +216,7 @@ export const multiselect = <Options extends Option<Value>[], Value extends Primi
     return new MultiSelectPrompt({
         options: opts.options,
         initialValue: opts.initialValue,
-        isAllowEmpty: opts.isAllowEmpty,
+        required: opts.required ?? true,
         cursorAt: opts.cursorAt,
         render() {
             let title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -114,6 +114,7 @@ export interface SelectOptions<Options extends Option<Value>[], Value extends Re
   message: string;
   options: Options;
   initialValue?: Options[number]["value"];
+  isAllowEmpty?: boolean;
 }
 export const select = <Options extends Option<Value>[], Value extends Readonly<string>>(
   opts: SelectOptions<Options, Value>
@@ -186,6 +187,7 @@ export const multiselect = <Options extends Option<Value>[], Value extends Reado
     return new MultiSelectPrompt({
         options: opts.options,
         initialValue: opts.initialValue,
+        isAllowEmpty: opts.isAllowEmpty,
         render() {
             let title = `${color.gray(bar)}\n${symbol(this.state)}  ${opts.message}\n`;
 


### PR DESCRIPTION
close #41 

It would be a little more flexible if we could use empty arrays in the multi-select prompt.
First, I think simply be used as an option (any thoughts are welcome)