### PR TITLE
fix(#40): unpipe sink on close

### DIFF
--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -181,6 +181,7 @@ export default class Prompt {
   }
 
   protected close() {
+    this.input.unpipe();
     this.input.removeListener('keypress', this.onKeypress)
     this.output.write('\n');
     setRawMode(this.input, false);


### PR DESCRIPTION
Apart from closing the readline interface, the write sink piped to the input needs to be detached.

Fixes #40