### PR TITLE
fix(#40): unpipe sink on close

### DIFF
--- a/.changeset/poor-snakes-beam.md
+++ b/.changeset/poor-snakes-beam.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": patch
+---
+
+Fix `MaxListenersExceededWarning` by detaching `stdin` listeners on close

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -181,6 +181,7 @@ export default class Prompt {
   }
 
   protected close() {
+    this.input.unpipe();
     this.input.removeListener('keypress', this.onKeypress)
     this.output.write('\n');
     setRawMode(this.input, false);


### PR DESCRIPTION
Apart from closing the readline interface, the write sink piped to the input needs to be detached.

Fixes https://github.com/natemoo-re/clack/issues/40