### PR TITLE
feat: add password prompt to `@clack/prompts`

### DIFF
--- a/.changeset/long-bees-turn.md
+++ b/.changeset/long-bees-turn.md
@@ -1,0 +1,6 @@
+---
+'@clack/prompts': patch
+'@clack/core': patch
+---
+
+Add a password prompt to `@clack/prompts`

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -20,6 +20,15 @@ async function main() {
 						if (value[0] !== '.') return 'Please enter a relative path.';
 					},
 				}),
+			password: () =>
+				p.password({
+					message: 'Provide a password',
+					mask: '🧹',
+					validate: (value) => {
+						if (!value) return 'Please enter a password.';
+						if (value.length < 5) return 'Password should have at least 5 characters.';
+					},
+				}),
 			type: ({ results }) =>
 				p.select({
 					message: `Pick a project type within "${results.path}"`,

--- a/packages/core/src/prompts/password.ts
+++ b/packages/core/src/prompts/password.ts
@@ -10,7 +10,7 @@ export default class PasswordPrompt extends Prompt {
 	get cursor() {
 		return this._cursor;
 	}
-	private get masked() {
+	get masked() {
 		return this.value
 			.split('')
 			.map(() => this._mask)

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -3,10 +3,10 @@ import {
 	ConfirmPrompt,
 	isCancel,
 	MultiSelectPrompt,
+	PasswordPrompt,
 	SelectPrompt,
 	State,
 	TextPrompt,
-	PasswordPrompt,
 } from '@clack/core';
 import isUnicodeSupported from 'is-unicode-supported';
 import color from 'picocolors';
@@ -111,7 +111,7 @@ export const password = (opts: PasswordOptions) => {
 					return `${title}${color.gray(S_BAR)}  ${color.dim(masked)}`;
 				case 'cancel':
 					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(masked ?? ''))}${
-						masked?.trim() ? '\n' + color.gray(S_BAR) : ''
+						masked ? '\n' + color.gray(S_BAR) : ''
 					}`;
 				default:
 					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}\n`;

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -6,6 +6,7 @@ import {
 	SelectPrompt,
 	State,
 	TextPrompt,
+	PasswordPrompt,
 } from '@clack/core';
 import isUnicodeSupported from 'is-unicode-supported';
 import color from 'picocolors';
@@ -80,6 +81,38 @@ export const text = (opts: TextOptions) => {
 					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
 						color.dim(this.value ?? '')
 					)}${this.value?.trim() ? '\n' + color.gray(S_BAR) : ''}`;
+				default:
+					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}\n`;
+			}
+		},
+	}).prompt() as Promise<string | symbol>;
+};
+
+export interface PasswordOptions {
+	message: string;
+	mask?: string;
+	validate?: (value: string) => string | void;
+}
+export const password = (opts: PasswordOptions) => {
+	return new PasswordPrompt({
+		validate: opts.validate,
+		mask: opts.mask,
+		render() {
+			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+			const value = this.valueWithCursor;
+			const masked = this.masked;
+
+			switch (this.state) {
+				case 'error':
+					return `${title.trim()}\n${color.yellow(S_BAR)}  ${masked}\n${color.yellow(
+						S_BAR_END
+					)}  ${color.yellow(this.error)}\n`;
+				case 'submit':
+					return `${title}${color.gray(S_BAR)}  ${color.dim(masked)}`;
+				case 'cancel':
+					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(masked ?? ''))}${
+						masked?.trim() ? '\n' + color.gray(S_BAR) : ''
+					}`;
 				default:
 					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}\n`;
 			}


### PR DESCRIPTION
I noticed that `@clack/prompts` doesn't export a password prompt, and I needed it in a project I'm currently working on 😅

Let me know if I should make any changes.  