### PR TITLE
bugfix: do not mutate initialValue array on multiselect prompt

### DIFF
--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -44,7 +44,7 @@ export default class MultiSelectPrompt<T extends { value: any }> extends Prompt 
 		});
 		this.options = opts.options;
 		this.cursor = this.options.findIndex(({ value }) => value === opts.cursorAt);
-		this.selectedValues = JSON.parse(JSON.stringify(opts.initialValue)) || [];
+		this.selectedValues = opts.initialValue ? opts.initialValue.slice() : [];
 		if (this.cursor === -1) this.cursor = 0;
 
 		this.on('cursor', (key) => {

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -44,7 +44,7 @@ export default class MultiSelectPrompt<T extends { value: any }> extends Prompt 
 		});
 		this.options = opts.options;
 		this.cursor = this.options.findIndex(({ value }) => value === opts.cursorAt);
-		this.selectedValues = opts.initialValue || [];
+		this.selectedValues = JSON.parse(JSON.stringify(opts.initialValue)) || [];
 		if (this.cursor === -1) this.cursor = 0;
 
 		this.on('cursor', (key) => {


### PR DESCRIPTION
Fixed #63. The array passed into `initialValue` on the `multi-select` prompt is not cloned, so the original array is mutated if a value not selected in the array is selected.

You could use `structuredClone` for this, but it got support from Node 17+, which might not be ideal. I choose the JSON way because it has good support and is not a shallow clone. If I am not mistaken the array should only include strings which won't make it a problem.