### PR TITLE
ref: multiselect 

### DIFF
--- a/.changeset/tough-plums-greet.md
+++ b/.changeset/tough-plums-greet.md
@@ -1,0 +1,8 @@
+---
+"@clack/core": patch
+"@clack/prompts": patch
+---
+
+Don't mutate `initialValue` in `multiselect`, fix parameter type for `validate()`.
+
+Credits to @banjo for the bug report and initial PR!

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -15,7 +15,8 @@ export default class MultiSelectPrompt<T extends { value: any }> extends Prompt 
 	}
 
 	private toggleValue() {
-		this.value = this.value.some(({ value }: T) => value === this._value.value)
+		const selected = this.value.some(({ value }: T) => value === this._value.value);
+		this.value = selected
 			? this.value.filter(({ value }: T) => value !== this._value.value)
 			: [...this.value, this._value];
 	}

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -1,4 +1,3 @@
-import color from 'picocolors';
 import Prompt, { PromptOptions } from './prompt';
 
 interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
@@ -10,42 +9,26 @@ interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<Mul
 export default class MultiSelectPrompt<T extends { value: any }> extends Prompt {
 	options: T[];
 	cursor: number = 0;
-	selectedValues: T[];
 
 	private get _value() {
 		return this.options[this.cursor];
 	}
 
-	private changeValue() {
-		const isValueAlreadySelected = this.selectedValues.some((value) => value === this._value.value);
-		if (isValueAlreadySelected) {
-			this.selectedValues = this.selectedValues.filter((value) => value !== this._value.value);
-		} else {
-			this.selectedValues.push(this._value.value);
-		}
+	private toggleValue() {
+		this.value = this.value.some(({ value }: T) => value === this._value.value)
+			? this.value.filter(({ value }: T) => value !== this._value.value)
+			: [...this.value, this._value];
 	}
 
 	constructor(opts: MultiSelectOptions<T>) {
-		if (!opts.validate) {
-			opts.validate = () => {
-				if (opts.required && this.selectedValues.length === 0)
-					return `Please select at least one option\n${color.reset(
-						color.dim(
-							`Press ${color.gray(color.bgWhite(color.inverse(' space ')))} to select, ${color.gray(
-								color.bgWhite(color.inverse(' enter '))
-							)} to submit`
-						)
-					)}`;
-			};
-		}
 		super(opts, false);
-		this.once('finalize', () => {
-			this.value = this.selectedValues;
-		});
+
 		this.options = opts.options;
-		this.cursor = this.options.findIndex(({ value }) => value === opts.cursorAt);
-		this.selectedValues = opts.initialValue || [];
-		if (this.cursor === -1) this.cursor = 0;
+		this.value = this.options.filter(({ value }) => opts.initialValue?.includes(value));
+		this.cursor = Math.max(
+			this.options.findIndex(({ value }) => value === opts.cursorAt),
+			0
+		);
 
 		this.on('cursor', (key) => {
 			switch (key) {
@@ -58,12 +41,7 @@ export default class MultiSelectPrompt<T extends { value: any }> extends Prompt 
 					this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1;
 					break;
 				case 'space':
-					this.changeValue();
-					break;
-				case 'enter':
-				case 'return':
-					this.state = 'submit';
-					this.close();
+					this.toggleValue();
 					break;
 			}
 		});


### PR DESCRIPTION
Debugging #63, I found room for improvements of the `multiselect` prompt.

- Move options type closer to implementation
- Move required validation to styled component (we don't want styles in the headless core components)
- Remove intermediate state, always keep `value` up-to-date
- Use immutable, instead of mutating underlying, data structures 
- Remove error prone type casts
- Remove superfluous `return` handler
- Don't do `close()` on submit (already taken care of in base prompt and not always desired)
- Replace init guard
- Fix parameter type for `validate()`
- Remove non-existing cursor key case
- Remove unused parameter

Fixes #63.
