### PR TITLE
break(group): replace `onCancel` by returning `cancel`

### DIFF
--- a/.changeset/tall-carrots-unite.md
+++ b/.changeset/tall-carrots-unite.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Replace `onCancel` handler for `group()` by returning `cancel` as results instead. Partial results are no longer wrapped in an object.

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,6 +1,6 @@
 import * as p from '@clack/prompts';
-import color from 'picocolors';
 import { setTimeout } from 'node:timers/promises';
+import color from 'picocolors';
 
 async function main() {
 	console.clear();
@@ -9,51 +9,48 @@ async function main() {
 
 	p.intro(`${color.bgCyan(color.black(' create-app '))}`);
 
-	const project = await p.group(
-		{
-			path: () =>
-				p.text({
-					message: 'Where should we create your project?',
-					placeholder: './sparkling-solid',
-					validate: (value) => {
-						if (!value) return 'Please enter a path.';
-						if (value[0] !== '.') return 'Please enter a relative path.';
-					},
-				}),
-			type: ({ results }) =>
-				p.select({
-					message: `Pick a project type within "${results.path}"`,
-					initialValue: 'ts',
-					options: [
-						{ value: 'ts', label: 'TypeScript' },
-						{ value: 'js', label: 'JavaScript' },
-						{ value: 'coffee', label: 'CoffeeScript', hint: 'oh no' },
-					],
-				}),
-			tools: () =>
-				p.multiselect({
-					message: 'Select additional tools.',
-					initialValue: ['prettier', 'eslint'],
-					options: [
-						{ value: 'prettier', label: 'Prettier', hint: 'recommended' },
-						{ value: 'eslint', label: 'ESLint', hint: 'recommended' },
-						{ value: 'stylelint', label: 'Stylelint' },
-						{ value: 'gh-action', label: 'GitHub Action' },
-					],
-				}),
-			install: () =>
-				p.confirm({
-					message: 'Install dependencies?',
-					initialValue: false,
-				}),
-		},
-		{
-			onCancel: () => {
-				p.cancel('Operation cancelled.');
-				process.exit(0);
-			},
-		}
-	);
+	const project = await p.group({
+		path: () =>
+			p.text({
+				message: 'Where should we create your project?',
+				placeholder: './sparkling-solid',
+				validate: (value) => {
+					if (!value) return 'Please enter a path.';
+					if (value[0] !== '.') return 'Please enter a relative path.';
+				},
+			}),
+		type: ({ path }) =>
+			p.select({
+				message: `Pick a project type within "${path}"`,
+				initialValue: 'ts',
+				options: [
+					{ value: 'ts', label: 'TypeScript' },
+					{ value: 'js', label: 'JavaScript' },
+					{ value: 'coffee', label: 'CoffeeScript', hint: 'oh no' },
+				],
+			}),
+		tools: () =>
+			p.multiselect({
+				message: 'Select additional tools.',
+				initialValue: ['prettier', 'eslint'],
+				options: [
+					{ value: 'prettier', label: 'Prettier', hint: 'recommended' },
+					{ value: 'eslint', label: 'ESLint', hint: 'recommended' },
+					{ value: 'stylelint', label: 'Stylelint' },
+					{ value: 'gh-action', label: 'GitHub Action' },
+				],
+			}),
+		install: () =>
+			p.confirm({
+				message: 'Install dependencies?',
+				initialValue: false,
+			}),
+	});
+
+	if (p.isCancel(project)) {
+		p.cancel('Operation cancelled.');
+		process.exit(0);
+	}
 
 	if (project.install) {
 		const s = p.spinner();

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -125,34 +125,29 @@ s.stop('Installed via npm');
 
 ### Grouping
 
-Grouping prompts together is a great way to keep your code organized. This accepts a JSON object with a name that can be used to reference the group later. The second argument is an optional but has a `onCancel` callback that will be called if the user cancels one of the prompts in the group.
+Group prompts together to keep your code organized. Returns results of each prompt accessible by name. If one prompt is cancelled, the entire group is cancelled and `cancel` is returned instead. Each prompt factory function is passed the results of previous prompts.
 
 ```js
 import * as p from '@clack/prompts';
 
-const group = await p.group(
-  {
-    name: () => p.text({ message: 'What is your name?' }),
-    age: () => p.text({ message: 'What is your age?' }),
-    color: ({ results }) =>
-      p.multiselect({
-        message: `What is your favorite color ${results.name}?`,
-        options: [
-          { value: 'red', label: 'Red' },
-          { value: 'green', label: 'Green' },
-          { value: 'blue', label: 'Blue' },
-        ],
-      }),
-  },
-  {
-    // On Cancel callback that wraps the group
-    // So if the user cancels one of the prompts in the group this function will be called
-    onCancel: ({ results }) => {
-      p.cancel('Operation cancelled.');
-      process.exit(0);
-    },
-  }
-);
+const group = await p.group({
+  name: () => p.text({ message: 'What is your name?' }),
+  age: () => p.text({ message: 'What is your age?' }),
+  color: ({ name }) =>
+    p.multiselect({
+      message: `What is your favorite color ${name}?`,
+      options: [
+        { value: 'red', label: 'Red' },
+        { value: 'green', label: 'Green' },
+        { value: 'blue', label: 'Blue' },
+      ],
+    }),
+});
+
+if (p.isCancel(group)) {
+  p.cancel('Operation cancelled.');
+  process.exit(0);
+}
 
 console.log(group.name, group.age, group.color);
 ```


### PR DESCRIPTION
Might be a little controversial, but I still wanted to present the case, which I find favorable.

- Consistent API with individual prompts
- Less indirection => less confusing
- Don't wrap partial results in object => simplify destruction
- Same amount of LOC
- Rewrite docs
- Simplify implementation
- Remove nonsense `.catch()` handler
- Remove error prone `any` cast

**Note:** this would be a breaking change, so either we would have to hold off until `1.0.0` or be less semver strict (which I think is fine before `1.0.0` is released). Might want to do a `minor` at least? Changeset should be updated if so.
