### PR TITLE
password: split()+map()+join() -> replaceAll()

### DIFF
--- a/packages/core/src/prompts/password.ts
+++ b/packages/core/src/prompts/password.ts
@@ -11,10 +11,7 @@ export default class PasswordPrompt extends Prompt {
 		return this._cursor;
 	}
 	get masked() {
-		return this.value
-			.split('')
-			.map(() => this._mask)
-			.join('');
+		return this.value.replaceAll(/./g, this._mask);
 	}
 	constructor({ mask, ...opts }: PasswordOptions) {
 		super(opts);


### PR DESCRIPTION
Decided not to do the `extends TextPrompt` since there were competing event listeners.