### PR TITLE
ci: setup type-checking on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,5 @@ jobs:
           cache: "pnpm"
       - if: ${{ steps.cache-node.outputs.cache-hit != 'true' }}
         run: pnpm install
+      - run: pnpm build
       - run: pnpm type-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
+      - if: ${{ steps.cache-node.outputs.cache-hit != 'true' }}
+        run: pnpm install
+      - run: pnpm type-check

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "pnpm run format:code",
     "format:code": "prettier -w . --cache",
     "format:imports": "organize-imports-cli ./packages/*/tsconfig.json",
+    "type-check": "tsc",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
     "ci:publish": "changeset publish",
     "ci:format": "pnpm run format:imports && pnpm run format:code"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
+    "noEmit": true,
     "module": "ESNext",
     "target": "ESNext",
-    "declaration": true,
     "moduleResolution": "node",
-    "emitDeclarationOnly": true,
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "allowJs": true,
-    "types": ["node"]
-  }
+    "skipLibCheck": true,
+  },
+  "include": [
+    "packages"
+  ]
 }


### PR DESCRIPTION
Since unbuild doesn't type-check, there's been quite a few type-errors that got in.

Now CI will run TypeScript to make sure there are no errors.