### PR TITLE
async validate

### DIFF
--- a/.changeset/cool-rats-cheat.md
+++ b/.changeset/cool-rats-cheat.md
@@ -1,0 +1,6 @@
+---
+'@clack/prompts': minor
+'@clack/core': minor
+---
+
+Allow `async` validation, add new `validate` state while validation is pending

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -15,7 +15,8 @@ async function main() {
 				p.text({
 					message: 'Where should we create your project?',
 					placeholder: './sparkling-solid',
-					validate: (value) => {
+					validate: async (value) => {
+						await setTimeout(299);
 						if (!value) return 'Please enter a path.';
 						if (value[0] !== '.') return 'Please enter a relative path.';
 					},

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -15,8 +15,7 @@ async function main() {
 				p.text({
 					message: 'Where should we create your project?',
 					placeholder: './sparkling-solid',
-					validate: async (value) => {
-						await setTimeout(299);
+					validate: (value) => {
 						if (!value) return 'Please enter a path.';
 						if (value[0] !== '.') return 'Please enter a relative path.';
 					},

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ export { default as GroupMultiSelectPrompt } from './prompts/group-multiselect';
 export { default as MultiSelectPrompt } from './prompts/multi-select';
 export { default as PasswordPrompt } from './prompts/password';
 export { default as Prompt, isCancel } from './prompts/prompt';
-export type { State } from './prompts/prompt';
+export type { State, Validator } from './prompts/prompt';
 export { default as SelectPrompt } from './prompts/select';
 export { default as SelectKeyPrompt } from './prompts/select-key';
 export { default as TextPrompt } from './prompts/text';

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -38,11 +38,15 @@ const aliases = new Map([
 ]);
 const keys = new Set(['up', 'down', 'left', 'right', 'space', 'enter']);
 
+export interface Validator<Value = any> {
+	(value: Value): string | void | Promise<string | void>;
+}
+
 export interface PromptOptions<Self extends Prompt> {
 	render(this: Omit<Self, 'prompt'>): string | void;
 	placeholder?: string;
 	initialValue?: any;
-	validate?: ((value: any) => string | void) | undefined;
+	validate?: Validator;
 	input?: Readable;
 	output?: Writable;
 	debug?: boolean;
@@ -153,7 +157,7 @@ export default class Prompt {
 		this.subscribers.clear();
 	}
 
-	private onKeypress(char: string, key?: Key) {
+	private async onKeypress(char: string, key?: Key) {
 		if (this.state === 'error') {
 			this.state = 'active';
 		}
@@ -172,7 +176,7 @@ export default class Prompt {
 
 		if (key?.name === 'return') {
 			if (this.opts.validate) {
-				const problem = this.opts.validate(this.value);
+				const problem = await this.opts.validate(this.value);
 				if (problem) {
 					this.error = problem;
 					this.state = 'error';

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -9,6 +9,7 @@ import {
 	SelectPrompt,
 	State,
 	TextPrompt,
+	Validator,
 } from '@clack/core';
 import isUnicodeSupported from 'is-unicode-supported';
 import color from 'picocolors';
@@ -63,7 +64,7 @@ export interface TextOptions {
 	placeholder?: string;
 	defaultValue?: string;
 	initialValue?: string;
-	validate?: (value: string) => string | void;
+	validate?: Validator<string>;
 }
 export const text = (opts: TextOptions) => {
 	return new TextPrompt({
@@ -99,7 +100,7 @@ export const text = (opts: TextOptions) => {
 export interface PasswordOptions {
 	message: string;
 	mask?: string;
-	validate?: (value: string) => string | void;
+	validate?: Validator<string>;
 }
 export const password = (opts: PasswordOptions) => {
 	return new PasswordPrompt({

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -20,6 +20,7 @@ export { isCancel } from '@clack/core';
 const unicode = isUnicodeSupported();
 const s = (c: string, fallback: string) => (unicode ? c : fallback);
 const S_STEP_ACTIVE = s('◆', '*');
+const S_STEP_VALIDATE = S_STEP_ACTIVE;
 const S_STEP_CANCEL = s('■', 'x');
 const S_STEP_ERROR = s('▲', 'x');
 const S_STEP_SUBMIT = s('◇', 'o');
@@ -50,6 +51,8 @@ const symbol = (state: State) => {
 		case 'initial':
 		case 'active':
 			return color.cyan(S_STEP_ACTIVE);
+		case 'validate':
+			return color.cyan(S_STEP_VALIDATE);
 		case 'cancel':
 			return color.red(S_STEP_CANCEL);
 		case 'error':
@@ -80,6 +83,8 @@ export const text = (opts: TextOptions) => {
 			const value = !this.value ? placeholder : this.valueWithCursor;
 
 			switch (this.state) {
+				case 'validate':
+					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}  ${color.dim('Validating...')}\n`;
 				case 'error':
 					return `${title.trim()}\n${color.yellow(S_BAR)}  ${value}\n${color.yellow(
 						S_BAR_END

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -84,7 +84,9 @@ export const text = (opts: TextOptions) => {
 
 			switch (this.state) {
 				case 'validate':
-					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}  ${color.dim('Validating...')}\n`;
+					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}  ${color.dim(
+						'Validating...'
+					)}\n`;
 				case 'error':
 					return `${title.trim()}\n${color.yellow(S_BAR)}  ${value}\n${color.yellow(
 						S_BAR_END
@@ -117,6 +119,10 @@ export const password = (opts: PasswordOptions) => {
 			const masked = this.masked;
 
 			switch (this.state) {
+				case 'validate':
+					return `${title}${color.cyan(S_BAR)}  ${masked}\n${color.cyan(S_BAR_END)}  ${color.dim(
+						'Validating...'
+					)}\n`;
 				case 'error':
 					return `${title.trim()}\n${color.yellow(S_BAR)}  ${masked}\n${color.yellow(
 						S_BAR_END


### PR DESCRIPTION
Took a stab at supporting async validation. 

Currently, the UX is suffering, though. The program seemingly hangs, without any feedback to the user. We should probably kick off a spinner or similar.

Potentially by emitting a `validate` event from core to allow styled prompts to take appropriate action? Or introducing a new state and doing an intermediate render?

Related to #92 