### PR TITLE
fix(#103): restore raw mode on unblock

### DIFF
--- a/.changeset/twelve-shrimps-report.md
+++ b/.changeset/twelve-shrimps-report.md
@@ -1,0 +1,5 @@
+---
+'@clack/core': patch
+---
+
+fix: restore raw mode on unblock

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -40,6 +40,7 @@ export function block({
 	return () => {
 		input.off('keypress', clear);
 		if (hideCursor) process.stdout.write(cursor.show);
+		if (input.isTTY) input.setRawMode(false);
 
 		// @ts-expect-error fix for https://github.com/nodejs/node/issues/31762#issuecomment-1441223907
 		rl.terminal = false;


### PR DESCRIPTION
The fix introduced by #80 seems to prevent control sequences from being sent. Restoring raw mode on top of that makes it work again.

Fixes #103 