### PR TITLE
feat: improve group `types` for readability

### DIFF
--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -657,7 +657,7 @@ export interface PromptGroupOptions<T> {
 	 * Control how the group can be canceled
 	 * if one of the prompts is canceled.
 	 */
-	onCancel?: (opts: { results: Partial<PromptGroupAwaitedReturn<T>> }) => void;
+	onCancel?: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<T>>> }) => void;
 }
 
 type Prettify<T> = {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -654,15 +654,19 @@ export type PromptGroupAwaitedReturn<T> = {
 
 export interface PromptGroupOptions<T> {
 	/**
-	 * Control how the group can be canceld
-	 * if one of the prompts is canceld.
+	 * Control how the group can be canceled
+	 * if one of the prompts is canceled.
 	 */
 	onCancel?: (opts: { results: Partial<PromptGroupAwaitedReturn<T>> }) => void;
 }
 
+type Prettify<T> = {
+	[P in keyof T]: T[P];
+} & {};
+
 export type PromptGroup<T> = {
 	[P in keyof T]: (opts: {
-		results: Partial<PromptGroupAwaitedReturn<T>>;
+		results: Prettify<Partial<PromptGroupAwaitedReturn<T>>>;
 	}) => void | Promise<T[P] | void>;
 };
 
@@ -673,7 +677,7 @@ export type PromptGroup<T> = {
 export const group = async <T>(
 	prompts: PromptGroup<T>,
 	opts?: PromptGroupOptions<T>
-): Promise<PromptGroupAwaitedReturn<T>> => {
+): Promise<Prettify<PromptGroupAwaitedReturn<T>>> => {
 	const results = {} as any;
 	const promptNames = Object.keys(prompts);
 

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -666,7 +666,7 @@ type Prettify<T> = {
 
 export type PromptGroup<T> = {
 	[P in keyof T]: (opts: {
-		results: Prettify<Partial<PromptGroupAwaitedReturn<T>>>;
+		results: Prettify<Partial<PromptGroupAwaitedReturn<Omit<T, P>>>>;
 	}) => void | Promise<T[P] | void>;
 };
 


### PR DESCRIPTION
This PR aims to improve type readability of `group` function, introducing `Prettify` type, which unwrap all the complex intern types to a top level one.

```ts
type Prettify<T> = {
	[P in keyof T]: T[P]
} & {}
```

It adds `Prettify` to `group` return type:

```ts
//before 
declare function group<T>(
	prompts: PromptGroup<T>,
	opts?: PromptGroupOptions<T>
): Promise<PromptGroupAwaitedReturn<T>>;

const result = await group({ foo: () => text({} as any) });
//    ^? const result: PromptGroupAwaitedReturn<{ foo: string | symbol }>


// after
declare function group<T>(
	prompts: PromptGroup<T>,
	opts?: PromptGroupOptions<T>
): Promise<Prettify<PromptGroupAwaitedReturn<T>>>;

const result = await group({ foo: () => text({} as any) });
//    ^? const result: { foo: string }
```

And to `results` param, I also took e the freedom to `Omit` the current key:

```ts
// before
type PromptGroup<T> = {
	[P in keyof T]: (opts: {
			results: Partial<PromptGroupAwaitedReturn<T>>;
	}) => void | Promise<T[P] | void>;
};

interface PromptGroupOptions<T> {
	onCancel?: (opts: { results: Partial<PromptGroupAwaitedReturn<T>> }) => void;
}

group({
	foo: () => text({} as any),
	bar: ({ results }) => text({} as any)
	//      ^? results: Partial<PromptGroupAwaitedReturn<{ foo: string | symbol; bar: unknown }>>
}, {
  onCancel: ({ results }) => {}
  //           ^? results: Partial<PromptGroupAwaitedReturn<{ foo: string | symbol; bar: unknown }>>
})


// after
type PromptGroup<T> = {
	[P in keyof T]: (opts: {
			results: Prettify<Partial<PromptGroupAwaitedReturn<Omit<T, P>>>>;
	}) => void | Promise<T[P] | void>;
};

interface PromptGroupOptions<T> {
	onCancel?: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<T>>> }) => void;
}

group({
	foo: () => text({} as any),
	bar: ({ results }) => text({} as any)
	//      ^? results: { foo?: string | undefined }
}, {
  onCancel: ({ results }) => {}
  //           ^? results: { foo?: string | undefined, bar?: unknown }
})
```
