### PR TITLE
Prettify group return type

### DIFF
--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -58,6 +58,8 @@ const symbol = (state: State) => {
 	}
 };
 
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
 export interface TextOptions {
 	message: string;
 	placeholder?: string;
@@ -673,7 +675,7 @@ export type PromptGroup<T> = {
 export const group = async <T>(
 	prompts: PromptGroup<T>,
 	opts?: PromptGroupOptions<T>
-): Promise<PromptGroupAwaitedReturn<T>> => {
+): Promise<Prettify<PromptGroupAwaitedReturn<T>>> => {
 	const results = {} as any;
 	const promptNames = Object.keys(prompts);
 


### PR DESCRIPTION
👋 tiny enhancement PR - I noticed that the return type exposed to consumers of `select` is wrapped by `PromptGroupAwaitedReturn`:

<img width="510" alt="Screenshot 2023-03-14 at 2 31 02 PM" src="https://user-images.githubusercontent.com/24602724/225103582-e2019f14-7dc6-4d07-832b-0e37cbebcf4a.png">

This has two undesirable consequences:
- `PromptGroupAwaitedReturn` is an abstraction which consumers shouldn't worry about - functionally, they get back a bare object so the types should reflect that
- `PromptGroupAwaitedReturn` implicitly strips `symbol` types from keys - ideally, consumers shouldn't worry about this either and instead just get back the types representing returned values

To make this more clear, this PR wraps the return in a `Prettify` helper type to make the exposed type a bare object:

<img width="516" alt="Screenshot 2023-03-14 at 2 30 32 PM" src="https://user-images.githubusercontent.com/24602724/225103580-7fa2e330-17de-4e77-8a5b-fb6fe178662b.png">

This should be a functional noop, but let me know if you notice any undesirable consequences! This pattern is also used [a fair amount](https://sourcegraph.com/search?q=context%3Aglobal+lang%3ATypeScript+%22%26+%7B%7D%22&patternType=standard&sm=1&groupBy=repo) in other TypeScript projects.