### PR TITLE
feat(#106): `spinner` hook to handle process exit

### DIFF
--- a/.changeset/ninety-ravens-smoke.md
+++ b/.changeset/ninety-ravens-smoke.md
@@ -1,0 +1,5 @@
+---
+'@clack/prompts': patch
+---
+
+Fix `spinner` conflict with terminal on error between `spinner.start()` and `spinner.stop()`

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -657,7 +657,7 @@ export interface PromptGroupOptions<T> {
 	 * Control how the group can be canceled
 	 * if one of the prompts is canceled.
 	 */
-	onCancel?: (opts: { results: Partial<PromptGroupAwaitedReturn<T>> }) => void;
+	onCancel?: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<T>>> }) => void;
 }
 
 type Prettify<T> = {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -654,15 +654,19 @@ export type PromptGroupAwaitedReturn<T> = {
 
 export interface PromptGroupOptions<T> {
 	/**
-	 * Control how the group can be canceld
-	 * if one of the prompts is canceld.
+	 * Control how the group can be canceled
+	 * if one of the prompts is canceled.
 	 */
 	onCancel?: (opts: { results: Partial<PromptGroupAwaitedReturn<T>> }) => void;
 }
 
+type Prettify<T> = {
+	[P in keyof T]: T[P];
+} & {};
+
 export type PromptGroup<T> = {
 	[P in keyof T]: (opts: {
-		results: Partial<PromptGroupAwaitedReturn<T>>;
+		results: Prettify<Partial<PromptGroupAwaitedReturn<T>>>;
 	}) => void | Promise<T[P] | void>;
 };
 
@@ -673,7 +677,7 @@ export type PromptGroup<T> = {
 export const group = async <T>(
 	prompts: PromptGroup<T>,
 	opts?: PromptGroupOptions<T>
-): Promise<PromptGroupAwaitedReturn<T>> => {
+): Promise<Prettify<PromptGroupAwaitedReturn<T>>> => {
 	const results = {} as any;
 	const promptNames = Object.keys(prompts);
 

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -666,7 +666,7 @@ type Prettify<T> = {
 
 export type PromptGroup<T> = {
 	[P in keyof T]: (opts: {
-		results: Prettify<Partial<PromptGroupAwaitedReturn<T>>>;
+		results: Prettify<Partial<PromptGroupAwaitedReturn<Omit<T, P>>>>;
 	}) => void | Promise<T[P] | void>;
 };
 


### PR DESCRIPTION
Closes  #106 

It adds a hook to `spinner`, that prints a default message and avoid terminal conflicts, it triggers on:
- Code exception
- Promise rejection
- Ctrl + C
- Kill process
- Process shutdown