### PR TITLE
feat: implement filter list

### DIFF
--- a/examples/test/index.ts
+++ b/examples/test/index.ts
@@ -1,0 +1,12 @@
+import * as p from '@clack/prompts';
+
+async function main() {
+	console.clear();
+	p.select({
+		options: [{ value: 'basic', label: 'Basic' }],
+		message: 'Select an example to run.',
+		enableFilter: true,
+	});
+}
+
+main().catch(console.error);

--- a/examples/test/package.json
+++ b/examples/test/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@example/test",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"dependencies": {
+		"@clack/core": "workspace:*",
+		"@clack/prompts": "workspace:*",
+		"picocolors": "^1.0.0"
+	},
+	"scripts": {
+		"start": "jiti ./index.ts"
+	},
+	"devDependencies": {
+		"jiti": "^1.17.0"
+	}
+}

--- a/examples/test/tsconfig.json
+++ b/examples/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "sisteransi": "^1.0.5"
   },
   "devDependencies": {
-    "wrap-ansi": "^8.1.0"
+    "wrap-ansi": "^8.1.0",
+		"fzf": "^0.5.2"
   }
 }

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -272,7 +272,7 @@ export default class Prompt {
 					this._filterKey += key;
 				}
 				const filtered = fzf.find(this._filterKey);
-				this.emit('filtered', filtered);
+				this.emit('filter', filtered);
 			});
 		}
 	}

--- a/packages/core/src/prompts/select.ts
+++ b/packages/core/src/prompts/select.ts
@@ -1,5 +1,5 @@
 import Prompt, { PromptOptions } from './prompt';
-import { Fzf, FzfResultItem } from 'fzf';
+import { type FzfResultItem } from 'fzf';
 
 interface SelectOptions<T extends { value: any }> extends PromptOptions<SelectPrompt<T>> {
 	options: T[];
@@ -43,7 +43,7 @@ export default class SelectPrompt<T extends { value: any }> extends Prompt {
 
 		// For filter
 		this.registerFilterer(this.options.map(({ value }) => value));
-		this.on('filtered', (filtered: FzfResultItem[]) => {
+		this.on('filter', (filtered: FzfResultItem[]) => {
 			this.cursor = 0;
 			if (filtered.length) {
 				this.options = filtered.map(

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "@clack/prompts",
-  "version": "0.6.3",
-  "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    },
-    "./package.json": "./package.json"
-  },
-  "types": "./dist/index.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/natemoo-re/clack",
-    "directory": "packages/prompts"
-  },
-  "bugs": {
-    "url": "https://github.com/natemoo-re/clack/issues"
-  },
-  "homepage": "https://github.com/natemoo-re/clack/tree/main/packages/prompts#readme",
-  "files": [
-    "dist",
-    "CHANGELOG.md"
-  ],
-  "author": {
-    "name": "Nate Moore",
-    "email": "nate@natemoo.re",
-    "url": "https://twitter.com/n_moore"
-  },
-  "license": "MIT",
-  "keywords": [
-    "ask",
-    "clack",
-    "cli",
-    "command-line",
-    "command",
-    "input",
-    "interact",
-    "interface",
-    "menu",
-    "prompt",
-    "prompts",
-    "stdin",
-    "ui"
-  ],
-  "packageManager": "pnpm@7.6.0",
-  "scripts": {
-    "build": "unbuild",
-    "prepack": "pnpm build"
-  },
-  "dependencies": {
-    "@clack/core": "^0.3.2",
-    "picocolors": "^1.0.0",
-    "sisteransi": "^1.0.5"
-  },
-  "devDependencies": {
-    "is-unicode-supported": "^1.3.0"
-  },
-  "bundledDependencies": [
-    "is-unicode-supported"
-  ]
+	"name": "@clack/prompts",
+	"version": "0.6.3",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.mjs",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.cjs"
+		},
+		"./package.json": "./package.json"
+	},
+	"types": "./dist/index.d.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/natemoo-re/clack",
+		"directory": "packages/prompts"
+	},
+	"bugs": {
+		"url": "https://github.com/natemoo-re/clack/issues"
+	},
+	"homepage": "https://github.com/natemoo-re/clack/tree/main/packages/prompts#readme",
+	"files": [
+		"dist",
+		"CHANGELOG.md"
+	],
+	"author": {
+		"name": "Nate Moore",
+		"email": "nate@natemoo.re",
+		"url": "https://twitter.com/n_moore"
+	},
+	"license": "MIT",
+	"keywords": [
+		"ask",
+		"clack",
+		"cli",
+		"command-line",
+		"command",
+		"input",
+		"interact",
+		"interface",
+		"menu",
+		"prompt",
+		"prompts",
+		"stdin",
+		"ui"
+	],
+	"packageManager": "pnpm@7.6.0",
+	"scripts": {
+		"build": "unbuild",
+		"prepack": "pnpm build"
+	},
+	"dependencies": {
+		"@clack/core": "^0.3.2",
+		"picocolors": "^1.0.0",
+		"sisteransi": "^1.0.5"
+	},
+	"devDependencies": {
+		"is-unicode-supported": "^1.3.0"
+	},
+	"bundledDependencies": [
+		"is-unicode-supported"
+	]
 }

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -178,6 +178,7 @@ export interface SelectOptions<Options extends Option<Value>[], Value> {
 	message: string;
 	options: Options;
 	initialValue?: Value;
+	enableFilter?: boolean;
 }
 
 export const select = <Options extends Option<Value>[], Value>(
@@ -200,6 +201,7 @@ export const select = <Options extends Option<Value>[], Value>(
 	return new SelectPrompt({
 		options: opts.options,
 		initialValue: opts.initialValue,
+		enableFilter: opts.enableFilter,
 		render() {
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
 
@@ -212,7 +214,7 @@ export const select = <Options extends Option<Value>[], Value>(
 						'cancelled'
 					)}\n${color.gray(S_BAR)}`;
 				default: {
-					return `${title}${color.cyan(S_BAR)}  ${this.options
+					return `${this.getFilterKey()}\n${title}${color.cyan(S_BAR)}  ${this.options
 						.map((option, i) => opt(option, i === this.cursor ? 'active' : 'inactive'))
 						.join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
 				}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -205,6 +205,11 @@ export const select = <Options extends Option<Value>[], Value>(
 		render() {
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
 
+			const filterKey = this.getFilterKey().length
+				? this.getFilterKey()
+				: color.gray('Type to filter...');
+			const filterer = opts.enableFilter ? `  > ${filterKey}\n${color.cyan(S_BAR)}  ` : '';
+
 			switch (this.state) {
 				case 'submit':
 					return `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor], 'selected')}`;
@@ -214,7 +219,7 @@ export const select = <Options extends Option<Value>[], Value>(
 						'cancelled'
 					)}\n${color.gray(S_BAR)}`;
 				default: {
-					return `${this.getFilterKey()}\n${title}${color.cyan(S_BAR)}  ${this.options
+					return `${title}${color.cyan(S_BAR)}${filterer}${this.options
 						.map((option, i) => opt(option, i === this.cursor ? 'active' : 'inactive'))
 						.join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
 				}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,22 @@ importers:
     devDependencies:
       jiti: 1.17.0
 
+  examples/test:
+    specifiers:
+      '@clack/core': workspace:*
+      '@clack/prompts': workspace:*
+      jiti: ^1.17.0
+      picocolors: ^1.0.0
+    dependencies:
+      '@clack/core': link:../../packages/core
+      '@clack/prompts': link:../../packages/prompts
+      picocolors: 1.0.0
+    devDependencies:
+      jiti: 1.17.1
+
   packages/core:
     specifiers:
+      fzf: ^0.5.2
       picocolors: ^1.0.0
       sisteransi: ^1.0.5
       wrap-ansi: ^8.1.0
@@ -55,6 +69,7 @@ importers:
       picocolors: 1.0.0
       sisteransi: 1.0.5
     devDependencies:
+      fzf: 0.5.2
       wrap-ansi: 8.1.0
 
   packages/prompts:
@@ -1489,6 +1504,10 @@ packages:
 
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+    dev: true
+
+  /fzf/0.5.2:
+    resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
     dev: true
 
   /gensync/1.0.0-beta.2:


### PR DESCRIPTION
Quick preview:

![preview](https://github.com/natemoo-re/clack/assets/49969959/344a358b-5e75-4a11-8905-1bc45854bc01)

Currently stage: *draft*

Need some feedback and suggestions:

- Do we need to separate the filter mode to avoid key conflicts caused by movement (hjkl) and selection (space) in normal mode?

usage:

```ts
p.select({
  options: [{ value: 'basic', label: 'Basic' }],
  message: 'Select an example to run.',
  enableFilter: true, // enable filterable
});
```