### PR TITLE
feat(@clack/prompts): multiline support

### DIFF
--- a/.changeset/popular-buses-buy.md
+++ b/.changeset/popular-buses-buy.md
@@ -1,0 +1,5 @@
+---
+'@clack/prompts': patch
+---
+
+Support multiline texts

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "organize-imports-cli": "^0.10.0",
     "prettier": "^2.8.4",
     "typescript": "^4.9.5",
-    "unbuild": "^1.1.2"
+    "unbuild": "1.1.2"
   },
   "packageManager": "pnpm@7.6.0",
   "volta": {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -75,7 +75,7 @@ function formatTextWithMaxWidth(
 	const endSymbol = options?.endSymbol ?? defaultSymbol;
 
 	const terminalWidth = process.stdout.columns || 80;
-	const maxWidth = options?.maxWidth ?? terminalWidth - 2;
+	const maxWidth = options?.maxWidth ?? terminalWidth;
 
 	const formattedLines: string[] = [];
 	const paragraphs = text.split(/\n/g);
@@ -85,8 +85,19 @@ function formatTextWithMaxWidth(
 		const words = paragraph.split(/\s/g);
 
 		for (const word of words) {
-			if (strLength(currentLine) + strLength(word) + 1 <= maxWidth) {
+			if (strLength(currentLine + word) + 3 <= maxWidth) {
 				currentLine += ` ${word}`;
+			} else if (strLength(word) + 2 >= maxWidth) {
+				const splitIndex = maxWidth - strLength(currentLine) - 3;
+				formattedLines.push(currentLine + ' ' + word.slice(0, splitIndex));
+
+				const chunkLength = maxWidth - 2;
+				let chunk = word.slice(splitIndex);
+				while (strLength(chunk) >= chunkLength) {
+					formattedLines.push(chunk.slice(0, chunkLength));
+					chunk = chunk.slice(chunkLength);
+				}
+				currentLine = chunk;
 			} else {
 				formattedLines.push(currentLine);
 				currentLine = word;

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -88,7 +88,7 @@ function formatTextWithMaxWidth(
 
 				const chunkLength = maxWidth - 2;
 				let chunk = word.slice(splitIndex);
-				while (strLength(chunk) >= chunkLength) {
+				while (strLength(chunk) > chunkLength) {
 					formattedLines.push(chunk.slice(0, chunkLength));
 					chunk = chunk.slice(chunkLength);
 				}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -779,23 +779,48 @@ export const log = {
 		);
 	},
 	info: (message: string) => {
-		log.message(message, { symbol: color.blue(S_INFO) });
+		process.stdout.write(
+			formatTextWithMaxWidth(message, {
+				initialSymbol: color.blue(S_INFO),
+				defaultSymbol: color.blue(S_BAR),
+			})
+		);
 	},
 	success: (message: string) => {
-		log.message(message, { symbol: color.green(S_SUCCESS) });
+		process.stdout.write(
+			formatTextWithMaxWidth(message, {
+				initialSymbol: color.green(S_SUCCESS),
+				defaultSymbol: color.green(S_BAR),
+			})
+		);
 	},
 	step: (message: string) => {
-		log.message(message, { symbol: color.green(S_STEP_SUBMIT) });
+		process.stdout.write(
+			formatTextWithMaxWidth(message, {
+				initialSymbol: color.green(S_STEP_SUBMIT),
+				defaultSymbol: color.green(S_BAR),
+			})
+		);
 	},
 	warn: (message: string) => {
-		log.message(message, { symbol: color.yellow(S_WARN) });
+		process.stdout.write(
+			formatTextWithMaxWidth(message, {
+				initialSymbol: color.yellow(S_WARN),
+				defaultSymbol: color.yellow(S_BAR),
+			})
+		);
 	},
 	/** alias for `log.warn()`. */
 	warning: (message: string) => {
 		log.warn(message);
 	},
 	error: (message: string) => {
-		log.message(message, { symbol: color.red(S_ERROR) });
+		process.stdout.write(
+			formatTextWithMaxWidth(message, {
+				initialSymbol: color.red(S_ERROR),
+				defaultSymbol: color.red(S_BAR),
+			})
+		);
 	},
 };
 

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -737,7 +737,7 @@ export const cancel = (message = '') => {
 	process.stdout.write(
 		formatTextWithMaxWidth(message, {
 			defaultSymbol: color.gray(S_BAR),
-			initialSymbol: color.gray(S_BAR_END),
+			endSymbol: color.gray(S_BAR_END),
 			lineWrapper: color.red,
 		}) + '\n\n'
 	);

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -704,7 +704,7 @@ const strLength = (str: string) => {
 	if (!str) return 0;
 
 	const colorCodeRegex = /\x1B\[[0-9;]*[mG]/g;
-	const arr = [...str.replace(colorCodeRegex, '')];
+	const arr = [...strip(str.replace(colorCodeRegex, ''))];
 	let len = 0;
 
 	for (const char of arr) {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -473,69 +473,81 @@ export const multiselect = <Options extends Option<Value>[], Value>(
 				)}`;
 		},
 		render() {
-			let title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+			let title = [
+				color.gray(S_BAR),
+				formatTextWithMaxWidth(opts.message, { initialSymbol: symbol(this.state) }),
+			].join('\n');
 
 			switch (this.state) {
 				case 'submit': {
-					return `${title}${color.gray(S_BAR)}  ${
-						this.options
-							.filter(({ value }) => this.value.includes(value))
-							.map((option) => opt(option, 'submitted'))
-							.join(color.dim(', ')) || color.dim('none')
-					}`;
+					return [
+						title,
+						formatTextWithMaxWidth(
+							this.options
+								.filter(({ value }) => this.value.includes(value))
+								.map((option) => opt(option, 'submitted'))
+								.join(color.dim(', ')),
+						),
+					].join('\n');
 				}
 				case 'cancel': {
 					const label = this.options
 						.filter(({ value }) => this.value.includes(value))
-						.map((option) => opt(option, 'cancelled'))
 						.join(color.dim(', '));
-					return `${title}${color.gray(S_BAR)}  ${
-						label.trim() ? `${label}\n${color.gray(S_BAR)}` : ''
-					}`;
+					return [
+						title,
+						formatTextWithMaxWidth(label ?? '', {
+							defaultSymbol: color.gray(S_BAR),
+							endSymbol: color.gray(S_BAR_END),
+							lineWrapper: (line) => color.strikethrough(color.dim(line)),
+						}),
+					].join('\n');
 				}
 				case 'error': {
-					const footer = this.error
-						.split('\n')
-						.map((ln, i) =>
-							i === 0 ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}` : `   ${ln}`
-						)
-						.join('\n');
-					return (
-						title +
-						color.yellow(S_BAR) +
-						'  ' +
+					return [
+						title,
 						this.options
 							.map((option, i) => {
 								const selected = this.value.includes(option.value);
 								const active = i === this.cursor;
+								let line = '';
 								if (active && selected) {
-									return opt(option, 'active-selected');
+									line = opt(option, 'active-selected');
+								} else if (selected) {
+									line = opt(option, 'selected');
+								} else {
+									line = opt(option, active ? 'active' : 'inactive');
 								}
-								if (selected) {
-									return opt(option, 'selected');
-								}
-								return opt(option, active ? 'active' : 'inactive');
+								return formatTextWithMaxWidth(line);
 							})
-							.join(`\n${color.yellow(S_BAR)}  `) +
-						'\n' +
-						footer +
-						'\n'
-					);
+							.join('\n'),
+						formatTextWithMaxWidth(this.error, {
+							defaultSymbol: color.yellow(S_BAR),
+							lineWrapper: color.yellow,
+							endSymbol: color.yellow(S_BAR_END),
+						}),
+					].join('\n');
 				}
 				default: {
-					return `${title}${color.cyan(S_BAR)}  ${this.options
-						.map((option, i) => {
-							const selected = this.value.includes(option.value);
-							const active = i === this.cursor;
-							if (active && selected) {
-								return opt(option, 'active-selected');
-							}
-							if (selected) {
-								return opt(option, 'selected');
-							}
-							return opt(option, active ? 'active' : 'inactive');
-						})
-						.join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+					return [
+						title,
+						this.options
+							.map((option, i) => {
+								const selected = this.value.includes(option.value);
+								const active = i === this.cursor;
+								let line = '';
+								if (active && selected) {
+									line = opt(option, 'active-selected');
+								} else if (selected) {
+									line = opt(option, 'selected');
+								} else {
+									line = opt(option, active ? 'active' : 'inactive');
+								}
+								return formatTextWithMaxWidth(line);
+							})
+							.join('\n'),
+						color.cyan(S_BAR_END),
+					].join('\n');
 				}
 			}
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
       organize-imports-cli: ^0.10.0
       prettier: ^2.8.4
       typescript: ^4.9.5
-      unbuild: ^1.1.2
+      unbuild: 1.1.2
     devDependencies:
       '@changesets/cli': 2.26.0
       '@types/node': 18.13.0


### PR DESCRIPTION
# Multiline Support
Support multiline texts either with `\n`, or long ones that exceed terminal width, without breaking the layout

## List of supported prompts:
- [x] text
- [x] password
- [ ] confirm
    - Is just `yes`/`no`
- [x] select
- [ ] selectKey
    - It was made to handle short options
- [x] multiselect
- [ ] groupMultiselect
    - It was made to handle short options
- [x] note
- [x] intro
- [x] cancel
- [x] outro
- [x] log
- [x] spinner

## How to test
```
// From ~/clack
git remote add test-multiline https://github.com/Mist3rBru/clack.git
git checkout -b test-multiline
git pull test-multiline ml-example
pnpm build
cd examples/basic
npx jiti multiline.ts
```

Closes #101
Closes #132 
Relates #135 #111 #35