### PR TITLE
fix(@clack/core,@clack/prompts): add non empty opts type interface 

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,4 @@ export { default as SelectPrompt } from './prompts/select';
 export { default as SelectKeyPrompt } from './prompts/select-key';
 export { default as TextPrompt } from './prompts/text';
 export { block } from './utils';
+export type { NonEmptyArray } from './utility-types';

--- a/packages/core/src/prompts/group-multiselect.ts
+++ b/packages/core/src/prompts/group-multiselect.ts
@@ -1,14 +1,15 @@
+import { NonEmptyArray } from '../utility-types';
 import Prompt, { PromptOptions } from './prompt';
 
 interface GroupMultiSelectOptions<T extends { value: any }>
 	extends PromptOptions<GroupMultiSelectPrompt<T>> {
-	options: Record<string, T[]>;
+	options: Record<string, NonEmptyArray<T>>;
 	initialValues?: T['value'][];
 	required?: boolean;
 	cursorAt?: T['value'];
 }
 export default class GroupMultiSelectPrompt<T extends { value: any }> extends Prompt {
-	options: (T & { group: string | boolean })[];
+	options: NonEmptyArray<T & { group: string | boolean }>;
 	cursor: number = 0;
 
 	getGroupItems(group: string): T[] {

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -1,13 +1,14 @@
+import { NonEmptyArray } from '../utility-types';
 import Prompt, { PromptOptions } from './prompt';
 
 interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
-	options: T[];
+	options: MultiSelectPrompt<T>['options'];
 	initialValues?: T['value'][];
 	required?: boolean;
 	cursorAt?: T['value'];
 }
 export default class MultiSelectPrompt<T extends { value: any }> extends Prompt {
-	options: T[];
+	options: NonEmptyArray<T>;
 	cursor: number = 0;
 
 	private get _value() {

--- a/packages/core/src/prompts/select.ts
+++ b/packages/core/src/prompts/select.ts
@@ -2,11 +2,11 @@ import { NonEmptyArray } from '../utility-types';
 import Prompt, { PromptOptions } from './prompt';
 
 interface SelectOptions<T extends { value: any }> extends PromptOptions<SelectPrompt<T>> {
-	options: NonEmptyArray<T>;
+	options: SelectPrompt<T>['options'];
 	initialValue?: T['value'];
 }
 export default class SelectPrompt<T extends { value: any }> extends Prompt {
-	options: SelectOptions<T>['options'];
+	options: NonEmptyArray<T>;
 	cursor: number = 0;
 
 	private get _value() {

--- a/packages/core/src/prompts/select.ts
+++ b/packages/core/src/prompts/select.ts
@@ -1,11 +1,12 @@
+import { NonEmptyArray } from '../utility-types';
 import Prompt, { PromptOptions } from './prompt';
 
 interface SelectOptions<T extends { value: any }> extends PromptOptions<SelectPrompt<T>> {
-	options: T[];
+	options: NonEmptyArray<T>;
 	initialValue?: T['value'];
 }
 export default class SelectPrompt<T extends { value: any }> extends Prompt {
-	options: T[];
+	options: SelectOptions<T>['options'];
 	cursor: number = 0;
 
 	private get _value() {

--- a/packages/core/src/utility-types.ts
+++ b/packages/core/src/utility-types.ts
@@ -1,0 +1,1 @@
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -416,7 +416,7 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 
 export interface GroupMultiSelectOptions<Value> {
 	message: string;
-	options: Record<string, Option<Value>[]>;
+	options: Record<string, NonEmptyArray<Option<Value>>>;
 	initialValues?: Value[];
 	required?: boolean;
 	cursorAt?: Value;

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -4,6 +4,7 @@ import {
 	GroupMultiSelectPrompt,
 	isCancel,
 	MultiSelectPrompt,
+	NonEmptyArray,
 	PasswordPrompt,
 	SelectKeyPrompt,
 	SelectPrompt,
@@ -176,7 +177,7 @@ type Option<Value> = Value extends Primitive
 
 export interface SelectOptions<Value> {
 	message: string;
-	options: Option<Value>[];
+	options: NonEmptyArray<Option<Value>>;
 	initialValue?: Value;
 	maxItems?: number;
 }

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -300,7 +300,7 @@ export const selectKey = <Value extends string>(opts: SelectOptions<Value>) => {
 
 export interface MultiSelectOptions<Value> {
 	message: string;
-	options: Option<Value>[];
+	options: NonEmptyArray<Option<Value>>;
 	initialValues?: Value[];
 	required?: boolean;
 	cursorAt?: Value;


### PR DESCRIPTION
This PR addresses this issue https://github.com/natemoo-re/clack/issues/144.

The current implementation is erroring out at runtime, the implementation in this PR shows a type error in the IDE/tsc instead. 