### PR TITLE
feat(@clack/prompts): multiselect maxItems option

### DIFF
--- a/.changeset/bright-rules-yell.md
+++ b/.changeset/bright-rules-yell.md
@@ -1,0 +1,5 @@
+---
+'@clack/prompts': patch
+---
+
+Feat multiselect maxItems option


### PR DESCRIPTION
This PR this introduces maxItems option to `multiselect` prompt, using the same logic as `select` prompt. Now both use the same utility function limitOptions that handles this logic.