### PR TITLE
fix(@clack/prompts): clear `spinner`'s hooks on `spinner.stop`

### DIFF
--- a/.changeset/red-seas-try.md
+++ b/.changeset/red-seas-try.md
@@ -1,0 +1,5 @@
+---
+'@clack/prompts': patch
+---
+
+fix: clear `spinner` hooks on `spinner.stop`


### PR DESCRIPTION
This PR adds registration and clear steps to spinner's hooks