### PR TITLE
feat(@clack/prompts): dynamic max items

### DIFF
--- a/.changeset/light-laws-judge.md
+++ b/.changeset/light-laws-judge.md
@@ -1,0 +1,5 @@
+---
+'@clack/prompts': patch
+---
+
+feat: adaptative max items

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -68,9 +68,10 @@ interface LimitOptionsParams<TOption> {
 const limitOptions = <TOption>(params: LimitOptionsParams<TOption>): string[] => {
 	const { cursor, options, style } = params;
 
+	const paramMaxItems = params.maxItems ?? Infinity;
+	const outputMaxItems = Math.max(process.stdout.rows - 4, 0);
 	// We clamp to minimum 5 because anything less doesn't make sense UX wise
-	const maxItems =
-		params.maxItems === undefined ? process.stdout.rows - 4 : Math.max(params.maxItems, 5);
+	const maxItems = Math.min(outputMaxItems, Math.max(paramMaxItems, 5));
 	let slidingWindowLocation = 0;
 
 	if (cursor >= slidingWindowLocation + maxItems - 3) {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -8,7 +8,7 @@ import {
 	SelectKeyPrompt,
 	SelectPrompt,
 	State,
-	TextPrompt
+	TextPrompt,
 } from '@clack/core';
 import isUnicodeSupported from 'is-unicode-supported';
 import color from 'picocolors';
@@ -69,7 +69,8 @@ const limitOptions = <TOption>(params: LimitOptionsParams<TOption>): string[] =>
 	const { cursor, options, style } = params;
 
 	// We clamp to minimum 5 because anything less doesn't make sense UX wise
-	const maxItems = params.maxItems === undefined ? Infinity : Math.max(params.maxItems, 5);
+	const maxItems =
+		params.maxItems === undefined ? process.stdout.rows - 4 : Math.max(params.maxItems, 5);
 	let slidingWindowLocation = 0;
 
 	if (cursor >= slidingWindowLocation + maxItems - 3) {


### PR DESCRIPTION
This PR introduces a `maxItems` calculation based on available terminal rows. This ensures a responsive display, preventing issues caused by lists that might exceed the terminal's row capacity.

## Demo

https://github.com/natemoo-re/clack/assets/100330057/67d437fc-9d50-4241-aea6-a0b7710f6a3b




Closes #173 
