### PR TITLE
fix(@clack/core): keyboard input not working after await in spinner

### DIFF
--- a/.changeset/olive-walls-clean.md
+++ b/.changeset/olive-walls-clean.md
@@ -1,0 +1,5 @@
+---
+'@clack/core': patch
+---
+
+fix(@clack/core): keyboard input not working after await in spinner

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -4,6 +4,8 @@ import { stdin, stdout } from 'node:process';
 import * as readline from 'node:readline';
 import { cursor } from 'sisteransi';
 
+const isWindows = globalThis.process.platform.startsWith('win');
+
 export function block({
 	input = stdin,
 	output = stdout,
@@ -40,7 +42,9 @@ export function block({
 	return () => {
 		input.off('keypress', clear);
 		if (hideCursor) process.stdout.write(cursor.show);
-		if (input.isTTY) input.setRawMode(false);
+
+		// Prevent Windows specific issues: https://github.com/natemoo-re/clack/issues/176
+		if (input.isTTY && !isWindows) input.setRawMode(false);
 
 		// @ts-expect-error fix for https://github.com/nodejs/node/issues/31762#issuecomment-1441223907
 		rl.terminal = false;


### PR DESCRIPTION
Fix #176 

## Description
The issue occurred on Windows, when the await line between the spinner start and stop was present, causing the second following prompt to be unresponsive to key inputs (e.g., arrow keys or Ctrl-C), except for the [Enter] key. Additionally, this resulted in the duplication of the first option.

## Solution 
The solution is identify when it is running on Windows and do not change terminal's mode
```ts
if (input.isTTY && !isWindows) input.setRawMode(false);
```

### Tested Environment:

OS: Windows, Ubuntu
Node Version: v18.17.1
Package: @clack/prompts
Package Version: v0.7.0


## Snippet to Reproduce
```ts
const sp = p.spinner();
sp.start("start");
await setTimeout(2000);
sp.stop("stop");

const y = await p.confirm({
  message: "Test anyway?",
});

const x = await p.multiselect({
  message: "test",
  options: [
    { value: "a", label: "A", hint: "hint A" },
    { value: "b", label: "B", hint: "hint B" },
    { value: "c", label: "C", hint: "hint C" },
  ],
  required: false,
});
```
