### PR TITLE
feat: add support for signals to prompts

### DIFF
--- a/.changeset/mean-years-remain.md
+++ b/.changeset/mean-years-remain.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": minor
+---
+
+Add support for signals in prompts, allowing them to be aborted.

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -83,6 +83,7 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 		filter: (search: string, opt: Option<Value>) => {
 			return getFilteredOption(search, opt);
 		},
+		signal: opts.signal,
 		input: opts.input,
 		output: opts.output,
 		validate: opts.validate,
@@ -230,6 +231,7 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 			return undefined;
 		},
 		initialValue: opts.initialValues,
+		signal: opts.signal,
 		input: opts.input,
 		output: opts.output,
 		render() {

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -49,4 +49,5 @@ export const symbol = (state: State) => {
 export interface CommonOptions {
 	input?: Readable;
 	output?: Writable;
+	signal?: AbortSignal;
 }

--- a/packages/prompts/src/confirm.ts
+++ b/packages/prompts/src/confirm.ts
@@ -21,6 +21,7 @@ export const confirm = (opts: ConfirmOptions) => {
 	return new ConfirmPrompt({
 		active,
 		inactive,
+		signal: opts.signal,
 		input: opts.input,
 		output: opts.output,
 		initialValue: opts.initialValue ?? true,

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -78,6 +78,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 
 	return new GroupMultiSelectPrompt({
 		options: opts.options,
+		signal: opts.signal,
 		input: opts.input,
 		output: opts.output,
 		initialValues: opts.initialValues,

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -53,6 +53,7 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 
 	return new MultiSelectPrompt({
 		options: opts.options,
+		signal: opts.signal,
 		input: opts.input,
 		output: opts.output,
 		initialValues: opts.initialValues,

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -11,6 +11,7 @@ export const password = (opts: PasswordOptions) => {
 	return new PasswordPrompt({
 		validate: opts.validate,
 		mask: opts.mask ?? S_PASSWORD_MASK,
+		signal: opts.signal,
 		input: opts.input,
 		output: opts.output,
 		render() {

--- a/packages/prompts/src/select-key.ts
+++ b/packages/prompts/src/select-key.ts
@@ -27,6 +27,7 @@ export const selectKey = <Value extends string>(opts: SelectOptions<Value>) => {
 
 	return new SelectKeyPrompt({
 		options: opts.options,
+		signal: opts.signal,
 		input: opts.input,
 		output: opts.output,
 		initialValue: opts.initialValue,

--- a/packages/prompts/src/select.ts
+++ b/packages/prompts/src/select.ts
@@ -76,6 +76,7 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 
 	return new SelectPrompt({
 		options: opts.options,
+		signal: opts.signal,
 		input: opts.input,
 		output: opts.output,
 		initialValue: opts.initialValue,

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -35,6 +35,7 @@ export const spinner = ({
 	errorMessage,
 	frames = unicode ? ['◒', '◐', '◓', '◑'] : ['•', 'o', 'O', '0'],
 	delay = unicode ? 80 : 120,
+	signal,
 }: SpinnerOptions = {}): SpinnerResult => {
 	const isCI = isCIFn();
 
@@ -72,6 +73,10 @@ export const spinner = ({
 		process.on('SIGINT', signalEventHandler);
 		process.on('SIGTERM', signalEventHandler);
 		process.on('exit', handleExit);
+
+		if (signal) {
+			signal.addEventListener('abort', signalEventHandler);
+		}
 	};
 
 	const clearHooks = () => {
@@ -80,6 +85,10 @@ export const spinner = ({
 		process.removeListener('SIGINT', signalEventHandler);
 		process.removeListener('SIGTERM', signalEventHandler);
 		process.removeListener('exit', handleExit);
+
+		if (signal) {
+			signal.removeEventListener('abort', signalEventHandler);
+		}
 	};
 
 	const clearPrevMessage = () => {

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -17,6 +17,7 @@ export const text = (opts: TextOptions) => {
 		defaultValue: opts.defaultValue,
 		initialValue: opts.initialValue,
 		output: opts.output,
+		signal: opts.signal,
 		input: opts.input,
 		render() {
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;

--- a/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
@@ -1,5 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`autocomplete > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [32m●[39m Apple
+[36m│[39m  [2m○[22m [2mBanana[22m
+[36m│[39m  [2m○[22m [2mCherry[22m
+[36m│[39m  [2m○[22m [2mGrape[22m
+[36m│[39m  [2m○[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`autocomplete > limits displayed options when maxItems is set 1`] = `
 [
   "<cursor.hide>",
@@ -260,6 +280,26 @@ exports[`autocomplete > supports initialValue 1`] = `
   "<erase.down>",
   "[32m◇[39m  Select a fruit
 [90m│[39m  [2mCherry[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`autocompleteMultiselect > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/confirm.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/confirm.test.ts.snap
@@ -1,5 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`confirm (isCI = false) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  yes?
+[36m│[39m  [32m●[39m Yes [2m/[22m [2m○[22m [2mNo[22m
+[36m└[39m
+",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`confirm (isCI = false) > can cancel 1`] = `
 [
   "<cursor.hide>",
@@ -143,6 +157,20 @@ exports[`confirm (isCI = false) > right arrow moves to next choice 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mNo[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`confirm (isCI = true) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  yes?
+[36m│[39m  [32m●[39m Yes [2m/[22m [2m○[22m [2mNo[22m
+[36m└[39m
+",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/group-multi-select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/group-multi-select.test.ts.snap
@@ -1,5 +1,22 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`groupMultiselect (isCI = false) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  └ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`groupMultiselect (isCI = false) > can deselect an option 1`] = `
 [
   "<cursor.hide>",
@@ -515,6 +532,23 @@ exports[`groupMultiselect (isCI = false) > values can be non-primitive 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mvalue0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`groupMultiselect (isCI = true) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  └ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/multi-select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/multi-select.test.ts.snap
@@ -1,5 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`multiselect (isCI = false) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [36m◻[39m opt0
+[36m│[39m  [2m◻[22m [2mopt1[22m
+[36m└[39m
+",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`multiselect (isCI = false) > can cancel 1`] = `
 [
   "<cursor.hide>",
@@ -589,6 +604,21 @@ exports[`multiselect (isCI = false) > sliding window loops upwards 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mopt11[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`multiselect (isCI = true) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [36m◻[39m opt0
+[36m│[39m  [2m◻[22m [2mopt1[22m
+[36m└[39m
+",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/password.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/password.test.ts.snap
@@ -1,5 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`password (isCI = false) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[8m_[28m[27m
+[36m└[39m
+",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`password (isCI = false) > renders and clears validation errors 1`] = `
 [
   "<cursor.hide>",
@@ -134,6 +148,20 @@ exports[`password (isCI = false) > renders message 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m[2m[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`password (isCI = true) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[8m_[28m[27m
+[36m└[39m
+",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/select.test.ts.snap
@@ -1,5 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`select (isCI = false) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [32m●[39m opt0
+[36m│[39m  [2m○[22m [2mopt1[22m
+[36m└[39m
+",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`select (isCI = false) > can cancel 1`] = `
 [
   "<cursor.hide>",
@@ -136,6 +151,21 @@ exports[`select (isCI = false) > up arrow selects previous option 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mopt0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`select (isCI = true) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [32m●[39m opt0
+[36m│[39m  [2m○[22m [2mopt1[22m
+[36m└[39m
+",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -1,5 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`spinner (isCI = false) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+",
+  "[31m■[39m  Canceled
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`spinner (isCI = false) > indicator customization > custom delay 1`] = `
 [
   "<cursor.hide>",
@@ -459,6 +470,17 @@ exports[`spinner (isCI = false) > stop > renders submit symbol and stops spinner
   "<cursor.backward count=999>",
   "<erase.down>",
   "[32m◇[39m  
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`spinner (isCI = true) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+",
+  "[31m■[39m  Canceled
 ",
   "<cursor.show>",
 ]

--- a/packages/prompts/test/__snapshots__/text.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/text.test.ts.snap
@@ -1,5 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`text (isCI = false) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[8m_[28m[27m
+[36m└[39m
+",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`text (isCI = false) > can cancel 1`] = `
 [
   "<cursor.hide>",
@@ -243,6 +257,20 @@ exports[`text (isCI = false) > validation errors render and clear 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mxy[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = true) > can be aborted by a signal 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[8m_[28m[27m
+[36m└[39m
+",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { autocomplete, autocompleteMultiselect } from '../src/autocomplete.js';
+import { isCancel } from '../src/index.js';
 import { MockReadable, MockWritable } from './test-utils.js';
 
 describe('autocomplete', () => {
@@ -151,6 +152,22 @@ describe('autocomplete', () => {
 		expect(value).toBe('cherry');
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = autocomplete({
+			message: 'foo',
+			options: testOptions,
+			input,
+			output,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const value = await result;
+		expect(isCancel(value)).toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });
 
 describe('autocompleteMultiselect', () => {
@@ -186,6 +203,22 @@ describe('autocompleteMultiselect', () => {
 		input.emit('keypress', '', { name: 'tab' });
 		input.emit('keypress', '', { name: 'return' });
 		await result;
+		expect(output.buffer).toMatchSnapshot();
+	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = autocompleteMultiselect({
+			message: 'foo',
+			options: testOptions,
+			input,
+			output,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const value = await result;
+		expect(isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
 });

--- a/packages/prompts/test/confirm.test.ts
+++ b/packages/prompts/test/confirm.test.ts
@@ -135,4 +135,19 @@ describe.each(['true', 'false'])('confirm (isCI = %s)', (isCI) => {
 		expect(value).toBe(false);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = prompts.confirm({
+			message: 'yes?',
+			input,
+			output,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const value = await result;
+		expect(prompts.isCancel(value)).toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/group-multi-select.test.ts
+++ b/packages/prompts/test/group-multi-select.test.ts
@@ -348,4 +348,23 @@ describe.each(['true', 'false'])('groupMultiselect (isCI = %s)', (isCI) => {
 			expect(output.buffer).toMatchSnapshot();
 		});
 	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = prompts.groupMultiselect({
+			message: 'Select a fruit',
+			options: {
+				group1: [{ value: 'group1value0' }],
+				group2: [{ value: 'group2value0' }],
+			},
+			input,
+			output,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const value = await result;
+		expect(prompts.isCancel(value)).toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/multi-select.test.ts
+++ b/packages/prompts/test/multi-select.test.ts
@@ -299,4 +299,20 @@ describe.each(['true', 'false'])('multiselect (isCI = %s)', (isCI) => {
 		expect(prompts.isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = prompts.multiselect({
+			message: 'foo',
+			options: [{ value: 'opt0' }, { value: 'opt1' }],
+			input,
+			output,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const value = await result;
+		expect(prompts.isCancel(value)).toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/password.test.ts
+++ b/packages/prompts/test/password.test.ts
@@ -112,4 +112,19 @@ describe.each(['true', 'false'])('password (isCI = %s)', (isCI) => {
 		expect(prompts.isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = prompts.password({
+			message: 'foo',
+			input,
+			output,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const value = await result;
+		expect(prompts.isCancel(value)).toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/select.test.ts
+++ b/packages/prompts/test/select.test.ts
@@ -129,4 +129,20 @@ describe.each(['true', 'false'])('select (isCI = %s)', (isCI) => {
 		expect(value).toBe('opt0');
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = prompts.select({
+			message: 'foo',
+			options: [{ value: 'opt0' }, { value: 'opt1' }],
+			input,
+			output,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const value = await result;
+		expect(prompts.isCancel(value)).toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -340,4 +340,18 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			}
 		});
 	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = prompts.spinner({
+			output,
+			signal: controller.signal,
+		});
+
+		result.start('Testing');
+
+		controller.abort();
+
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/text.test.ts
+++ b/packages/prompts/test/text.test.ts
@@ -190,4 +190,19 @@ describe.each(['true', 'false'])('text (isCI = %s)', (isCI) => {
 		expect(value).toBe('');
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('can be aborted by a signal', async () => {
+		const controller = new AbortController();
+		const result = prompts.text({
+			message: 'foo',
+			input,
+			output,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const value = await result;
+		expect(prompts.isCancel(value)).toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
Adds support for `signal` to each of the prompts which do async work.

This means you can cancel a prompt by aborting the signal.

Fixes #337
