### PR TITLE
fix(autocomplete): show correct selection text

### DIFF
--- a/.changeset/violet-hornets-turn.md
+++ b/.changeset/violet-hornets-turn.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Update key binding text to show tab/space when navigating, and tab otherwise.

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -275,7 +275,7 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 					// Instructions
 					const instructions = [
 						`${color.dim('↑/↓')} to navigate`,
-						`${color.dim('Space:')} select`,
+						`${color.dim(this.isNavigating ? 'Space/Tab:' : 'Tab:')} select`,
 						`${color.dim('Enter:')} confirm`,
 						`${color.dim('Type:')} to search`,
 					];
@@ -315,5 +315,5 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 	});
 
 	// Return the result or cancel symbol
-	return prompt.prompt() as Promise<Value | symbol>;
+	return prompt.prompt() as Promise<Value[] | symbol>;
 };

--- a/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
@@ -298,8 +298,63 @@ exports[`autocompleteMultiselect > can be aborted by a signal 1`] = `
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mTab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`autocompleteMultiselect > can use navigation keys to select options 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select fruits
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mTab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m [2m[22m
+[36m│[39m  [2m◻[22m [2mApple[22m
+[36m│[39m  [2m◻[22m Banana
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace/Tab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=5>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [32m◼[39m Banana",
+  "<cursor.down count=5>",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=5>",
+  "<erase.down>",
+  "[36m│[39m  [32m◼[39m [2mBanana[22m
+[36m│[39m  [2m◻[22m Cherry
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace/Tab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=6>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [32m◼[39m Cherry",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select fruits
+[90m│[39m  [2m2 items selected[22m",
   "
 ",
   "<cursor.show>",
@@ -318,7 +373,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mTab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
@@ -332,7 +387,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mTab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=11>",
   "<cursor.down count=1>",
@@ -345,7 +400,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mTab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -221,4 +221,23 @@ describe('autocompleteMultiselect', () => {
 		expect(isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('can use navigation keys to select options', async () => {
+		const result = autocompleteMultiselect({
+			message: 'Select fruits',
+			options: testOptions,
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'down' });
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'down' });
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+		expect(value).toEqual(['banana', 'cherry']);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
When navigating, we now show `Tab/Space` to select the focused item.
When not navigating, we show `Tab` (since space is interpreted as text
input).

Fixes #361.
