### PR TITLE
fix: do nothing if spinner already stopped and stop called

### DIFF
--- a/.changeset/short-squids-battle.md
+++ b/.changeset/short-squids-battle.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Handle `stop` calls on spinners which have not yet been started.

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -159,6 +159,7 @@ export const spinner = ({
 	};
 
 	const stop = (msg = '', code = 0): void => {
+		if (!isSpinnerActive) return;
 		isSpinnerActive = false;
 		clearInterval(loop);
 		clearPrevMessage();

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -163,6 +163,12 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 
 			expect(output.buffer).toMatchSnapshot();
 		});
+
+		test('does not throw if called before start', () => {
+			const result = prompts.spinner({ output });
+
+			expect(() => result.stop()).not.toThrow();
+		});
 	});
 
 	describe('message', () => {


### PR DESCRIPTION
If you call `stop` while the spinner is already stopped, this will now
do nothing (i.e. return early).

fixes #381