### PR TITLE
docs: correct type verify command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ The `examples/` directory contains sample projects that demonstrate how to use C
    pnpm lint
    
    # Verify type correctness
-   pnpm type-check
+   pnpm types
    
    # Run tests
    pnpm test


### PR DESCRIPTION
I think it is a typo. The type check command is `pnpm types`, not `pnpm type-check`

<img width="740" height="192" alt="image" src="https://github.com/user-attachments/assets/ead67e0c-b11b-4dfd-a535-507caa45f785" />
