### PR TITLE
fix: strip destructive ANSI codes from task logs

### DIFF
--- a/.changeset/evil-rats-turn.md
+++ b/.changeset/evil-rats-turn.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Strip destructive ANSI codes from task log messages.

--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -36,6 +36,10 @@ interface BufferEntry {
 	};
 }
 
+const stripDestructiveANSI = (input: string): string => {
+	return input.replace(/\x1b\[(?:\d+;)*\d*[ABCDEFGHfJKSTsu]|\x1b\[(s|u)/g, '');
+};
+
 /**
  * Renders a log which clears on success and remains on failure
  */
@@ -131,7 +135,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 		if ((mopts?.raw !== true || !lastMessageWasRaw) && buffer.value !== '') {
 			buffer.value += '\n';
 		}
-		buffer.value += msg;
+		buffer.value += stripDestructiveANSI(msg);
 		lastMessageWasRaw = mopts?.raw === true;
 		if (opts.limit !== undefined) {
 			const lines = buffer.value.split('\n');

--- a/packages/prompts/test/__snapshots__/task-log.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/task-log.test.ts.snap
@@ -627,6 +627,28 @@ exports[`taskLog (isCI = false) > message > can write multiple lines 1`] = `
 ]
 `;
 
+exports[`taskLog (isCI = false) > message > destructive ansi codes are stripped 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  foo
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [2mline 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2mline 1[22m
+[90m│[39m  [2mline 2 bad ansi![22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2mline 1[22m
+[90m│[39m  [2mline 2 bad ansi![22m
+[90m│[39m  [2mline 3[22m
+",
+]
+`;
+
 exports[`taskLog (isCI = false) > message > enforces limit if set 1`] = `
 [
   "[90m│[39m
@@ -1355,6 +1377,19 @@ exports[`taskLog (isCI = true) > message > can write multiple lines 1`] = `
 ",
   "[90m│[39m
 ",
+]
+`;
+
+exports[`taskLog (isCI = true) > message > destructive ansi codes are stripped 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  foo
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
 ]
 `;
 

--- a/packages/prompts/test/task-log.test.ts
+++ b/packages/prompts/test/task-log.test.ts
@@ -132,6 +132,20 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 
 			expect(output.buffer).toMatchSnapshot();
 		});
+
+		test('destructive ansi codes are stripped', async () => {
+			const log = prompts.taskLog({
+				input,
+				output,
+				title: 'foo',
+			});
+
+			log.message('line 1');
+			log.message('line 2\x1b[2K bad ansi!');
+			log.message('line 3');
+
+			expect(output.buffer).toMatchSnapshot();
+		});
 	});
 
 	describe('error', () => {


### PR DESCRIPTION
If you `message(str)` with a string containing ANSI codes, they will
cause all hell to break loose since they may change the cursor, erase
lines, etc.

This strips them from messages to avoid the problem.
