### PR TITLE
chore: fix lint around control chars

### DIFF
--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -37,6 +37,7 @@ interface BufferEntry {
 }
 
 const stripDestructiveANSI = (input: string): string => {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional
 	return input.replace(/\x1b\[(?:\d+;)*\d*[ABCDEFGHfJKSTsu]|\x1b\[(s|u)/g, '');
 };
 


### PR DESCRIPTION
We intentionally use control characters here, Biome is wrong in this
case.
