### PR TITLE
fix: show symbol when guide enabled

### DIFF
--- a/.changeset/tasty-candies-tie.md
+++ b/.changeset/tasty-candies-tie.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Show symbol when withGuide is true for log messages

--- a/packages/prompts/src/log.ts
+++ b/packages/prompts/src/log.ts
@@ -43,7 +43,7 @@ export const log = {
 			if (firstLine.length > 0) {
 				parts.push(`${prefix}${firstLine}`);
 			} else {
-				parts.push(hasGuide ? '' : symbol);
+				parts.push(hasGuide ? symbol : '');
 			}
 			for (const ln of lines) {
 				if (ln.length > 0) {

--- a/packages/prompts/test/__snapshots__/log.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/log.test.ts.snap
@@ -16,6 +16,22 @@ exports[`log (isCI = false) > info > renders info message 1`] = `
 ]
 `;
 
+exports[`log (isCI = false) > message > renders empty message correctly 1`] = `
+[
+  "[90m│[39m
+[90m│[39m
+",
+]
+`;
+
+exports[`log (isCI = false) > message > renders empty message with guide disabled 1`] = `
+[
+  "
+
+",
+]
+`;
+
 exports[`log (isCI = false) > message > renders message 1`] = `
 [
   "[90m│[39m
@@ -117,6 +133,22 @@ exports[`log (isCI = true) > info > renders info message 1`] = `
 [
   "[90m│[39m
 [34m●[39m  info message
+",
+]
+`;
+
+exports[`log (isCI = true) > message > renders empty message correctly 1`] = `
+[
+  "[90m│[39m
+[90m│[39m
+",
+]
+`;
+
+exports[`log (isCI = true) > message > renders empty message with guide disabled 1`] = `
+[
+  "
+
 ",
 ]
 `;

--- a/packages/prompts/test/log.test.ts
+++ b/packages/prompts/test/log.test.ts
@@ -85,6 +85,23 @@ describe.each(['true', 'false'])('log (isCI = %s)', (isCI) => {
 
 			expect(output.buffer).toMatchSnapshot();
 		});
+
+		test('renders empty message correctly', () => {
+			prompts.log.message('', {
+				output,
+			});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('renders empty message with guide disabled', () => {
+			prompts.log.message('', {
+				withGuide: false,
+				output,
+			});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
 	});
 
 	describe('info', () => {


### PR DESCRIPTION
Past-James got the symbol and `''` the wrong way around, meaning the
guide is currently showing when `withGuide: false`. This switcheroo's
them.
