### PR TITLE
fix: render guide with empty log lines

### DIFF
--- a/.changeset/long-friends-smile.md
+++ b/.changeset/long-friends-smile.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fixes missing guide when rendering empty log lines.

--- a/packages/prompts/src/log.ts
+++ b/packages/prompts/src/log.ts
@@ -49,7 +49,7 @@ export const log = {
 				if (ln.length > 0) {
 					parts.push(`${secondaryPrefix}${ln}`);
 				} else {
-					parts.push(hasGuide ? '' : secondarySymbol);
+					parts.push(hasGuide ? secondarySymbol : '');
 				}
 			}
 		}

--- a/packages/prompts/test/__snapshots__/log.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/log.test.ts.snap
@@ -16,6 +16,26 @@ exports[`log (isCI = false) > info > renders info message 1`] = `
 ]
 `;
 
+exports[`log (isCI = false) > message > renders empty lines correctly 1`] = `
+[
+  "[90m│[39m
+[90m│[39m  foo
+[90m│[39m
+[90m│[39m  bar
+",
+]
+`;
+
+exports[`log (isCI = false) > message > renders empty lines with guide disabled 1`] = `
+[
+  "
+foo
+
+bar
+",
+]
+`;
+
 exports[`log (isCI = false) > message > renders empty message correctly 1`] = `
 [
   "[90m│[39m
@@ -133,6 +153,26 @@ exports[`log (isCI = true) > info > renders info message 1`] = `
 [
   "[90m│[39m
 [34m●[39m  info message
+",
+]
+`;
+
+exports[`log (isCI = true) > message > renders empty lines correctly 1`] = `
+[
+  "[90m│[39m
+[90m│[39m  foo
+[90m│[39m
+[90m│[39m  bar
+",
+]
+`;
+
+exports[`log (isCI = true) > message > renders empty lines with guide disabled 1`] = `
+[
+  "
+foo
+
+bar
 ",
 ]
 `;

--- a/packages/prompts/test/log.test.ts
+++ b/packages/prompts/test/log.test.ts
@@ -102,6 +102,23 @@ describe.each(['true', 'false'])('log (isCI = %s)', (isCI) => {
 
 			expect(output.buffer).toMatchSnapshot();
 		});
+
+		test('renders empty lines correctly', () => {
+			prompts.log.message('foo\n\nbar', {
+				output,
+			});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('renders empty lines with guide disabled', () => {
+			prompts.log.message('foo\n\nbar', {
+				withGuide: false,
+				output,
+			});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
 	});
 
 	describe('info', () => {


### PR DESCRIPTION
When a log line is empty, we were previously showing no guide line. This
reintroduces it.
