### PR TITLE
fix(autocomplete): display placeholder only when user input is empty

### DIFF
--- a/.changeset/brown-banks-play.md
+++ b/.changeset/brown-banks-play.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fix placeholder rendering when using autocomplete.

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -91,10 +91,9 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 			// Title and message display
 			const headings = [`${color.gray(S_BAR)}`, `${symbol(this.state)}  ${opts.message}`];
 			const userInput = this.userInput;
-			const valueAsString = String(this.value ?? '');
 			const options = this.options;
 			const placeholder = opts.placeholder;
-			const showPlaceholder = valueAsString === '' && placeholder !== undefined;
+			const showPlaceholder = userInput === '' && placeholder !== undefined;
 
 			// Handle different states
 			switch (this.state) {

--- a/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
@@ -46,6 +46,39 @@ exports[`autocomplete > limits displayed options when maxItems is set 1`] = `
 ]
 `;
 
+exports[`autocomplete > placeholder is shown if set 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+[36m│[39m
+[36m│[39m  [2mSearch:[22m [2mType to search...[22m
+[36m│[39m  [32m●[39m Apple
+[36m│[39m  [2m○[22m [2mBanana[22m
+[36m│[39m  [2m○[22m [2mCherry[22m
+[36m│[39m  [2m○[22m [2mGrape[22m
+[36m│[39m  [2m○[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m g█[2m (2 matches)[22m
+[36m│[39m  [32m●[39m Grape
+[36m│[39m  [2m○[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2mGrape[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`autocomplete > renders bottom ellipsis when items do not fit 1`] = `
 [
   "<cursor.hide>",

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -225,6 +225,22 @@ describe('autocomplete', () => {
 		await result;
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('placeholder is shown if set', async () => {
+		const result = autocomplete({
+			message: 'Select a fruit',
+			placeholder: 'Type to search...',
+			options: testOptions,
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'g', { name: 'g' });
+		input.emit('keypress', '', { name: 'return' });
+		const value = await result;
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe('grape');
+	});
 });
 
 describe('autocompleteMultiselect', () => {


### PR DESCRIPTION
Fixes #439.
