### PR TITLE
feat: add `caseSensitive` option to select-key

### DIFF
--- a/.changeset/three-boxes-follow.md
+++ b/.changeset/three-boxes-follow.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": patch
+"@clack/core": patch
+---
+
+select-key: Fixed wrapping and added new `caseSensitive` option

--- a/packages/core/src/prompts/select-key.ts
+++ b/packages/core/src/prompts/select-key.ts
@@ -3,6 +3,7 @@ import Prompt, { type PromptOptions } from './prompt.js';
 export interface SelectKeyOptions<T extends { value: string }>
 	extends PromptOptions<T['value'], SelectKeyPrompt<T>> {
 	options: T[];
+	caseSensitive?: boolean;
 }
 export default class SelectKeyPrompt<T extends { value: string }> extends Prompt<T['value']> {
 	options: T[];
@@ -12,12 +13,24 @@ export default class SelectKeyPrompt<T extends { value: string }> extends Prompt
 		super(opts, false);
 
 		this.options = opts.options;
-		const keys = this.options.map(({ value: [initial] }) => initial?.toLowerCase());
+		const caseSensitive = opts.caseSensitive === true;
+		const keys = this.options.map(({ value: [initial] }) => {
+			return caseSensitive ? initial : initial?.toLowerCase();
+		});
 		this.cursor = Math.max(keys.indexOf(opts.initialValue), 0);
 
-		this.on('key', (key) => {
-			if (!key || !keys.includes(key)) return;
-			const value = this.options.find(({ value: [initial] }) => initial?.toLowerCase() === key);
+		this.on('key', (key, keyInfo) => {
+			if (!key) {
+				return;
+			}
+			const casedKey = caseSensitive && keyInfo.shift ? key.toUpperCase() : key;
+			if (!keys.includes(casedKey)) {
+				return;
+			}
+
+			const value = this.options.find(({ value: [initial] }) => {
+				return caseSensitive ? initial === casedKey : initial?.toLowerCase() === key;
+			});
 			if (value) {
 				this.value = value.value;
 				this.state = 'submit';

--- a/packages/prompts/test/__snapshots__/select-key.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/select-key.test.ts.snap
@@ -1,0 +1,541 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`text (isCI = false) > can cancel by pressing escape 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[31m■[39m  foo
+[90m│[39m  [9m[2mOption A[22m[29m
+[90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = false) > caseSensitive: true makes input case-sensitive 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option a
+[36m│[39m  [90m[47m[7m A [27m[49m[39m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption A[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = false) > caseSensitive: true makes options case-sensitive 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m A [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[31m■[39m  foo
+[90m│[39m  [9m[2mOption A[22m[29m
+[90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = false) > input is case-insensitive by default 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption A[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = false) > long cancelled labels are wrapped correctly 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select an option:
+[36m│[39m  [46m[90m a [39m[49m This is a somewhat long
+[36m│[39m   label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label 
+[36m│[39m  This is a somewhat long 
+[36m│[39m  label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Short label
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=16>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[31m■[39m  Select an option:
+[90m│[39m  [9m[2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label [22m
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label[22m[29m
+[90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = false) > long option labels are wrapped correctly 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select an option:
+[36m│[39m  [46m[90m a [39m[49m This is a somewhat long
+[36m│[39m   label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label 
+[36m│[39m  This is a somewhat long 
+[36m│[39m  label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Short label
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=16>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select an option:
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label [22m
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = false) > long submitted labels are wrapped correctly 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select an option:
+[36m│[39m  [46m[90m a [39m[49m This is a somewhat long
+[36m│[39m   label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label 
+[36m│[39m  This is a somewhat long 
+[36m│[39m  label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Short label
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=16>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select an option:
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label [22m
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = false) > options are case-insensitive by default 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m A [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption A[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = false) > renders message with options 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption A[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = false) > selects option by keypress 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption B[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = true) > can cancel by pressing escape 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[31m■[39m  foo
+[90m│[39m  [9m[2mOption A[22m[29m
+[90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = true) > caseSensitive: true makes input case-sensitive 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option a
+[36m│[39m  [90m[47m[7m A [27m[49m[39m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption A[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = true) > caseSensitive: true makes options case-sensitive 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m A [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[31m■[39m  foo
+[90m│[39m  [9m[2mOption A[22m[29m
+[90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = true) > input is case-insensitive by default 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption A[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = true) > long cancelled labels are wrapped correctly 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select an option:
+[36m│[39m  [46m[90m a [39m[49m This is a somewhat long
+[36m│[39m   label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label 
+[36m│[39m  This is a somewhat long 
+[36m│[39m  label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Short label
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=16>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[31m■[39m  Select an option:
+[90m│[39m  [9m[2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label [22m
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label[22m[29m
+[90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = true) > long option labels are wrapped correctly 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select an option:
+[36m│[39m  [46m[90m a [39m[49m This is a somewhat long
+[36m│[39m   label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label 
+[36m│[39m  This is a somewhat long 
+[36m│[39m  label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Short label
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=16>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select an option:
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label [22m
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = true) > long submitted labels are wrapped correctly 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select an option:
+[36m│[39m  [46m[90m a [39m[49m This is a somewhat long
+[36m│[39m   label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label 
+[36m│[39m  This is a somewhat long 
+[36m│[39m  label This is a somewhat 
+[36m│[39m  long label This is a 
+[36m│[39m  somewhat long label This is
+[36m│[39m   a somewhat long label This
+[36m│[39m   is a somewhat long label
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Short label
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=16>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select an option:
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label [22m
+[90m│[39m  [2mThis is a somewhat long [22m
+[90m│[39m  [2mlabel This is a somewhat [22m
+[90m│[39m  [2mlong label This is a [22m
+[90m│[39m  [2msomewhat long label This is[22m
+[90m│[39m  [2m a somewhat long label This[22m
+[90m│[39m  [2m is a somewhat long label[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = true) > options are case-insensitive by default 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m A [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption A[22m",
+  "
+",
+]
+`;
+
+exports[`text (isCI = true) > renders message with options 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption A[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = true) > selects option by keypress 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [46m[90m a [39m[49m Option A
+[36m│[39m  [90m[47m[7m b [27m[49m[39m Option B
+[36m└[39m
+",
+  "<cursor.show>",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mOption B[22m",
+  "
+",
+]
+`;

--- a/packages/prompts/test/select-key.test.ts
+++ b/packages/prompts/test/select-key.test.ts
@@ -1,0 +1,236 @@
+import { updateSettings } from '@clack/core';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as prompts from '../src/index.js';
+import { MockReadable, MockWritable } from './test-utils.js';
+
+describe.each(['true', 'false'])('text (isCI = %s)', (isCI) => {
+	let originalCI: string | undefined;
+	let output: MockWritable;
+	let input: MockReadable;
+
+	beforeAll(() => {
+		originalCI = process.env.CI;
+		process.env.CI = isCI;
+	});
+
+	afterAll(() => {
+		process.env.CI = originalCI;
+	});
+
+	beforeEach(() => {
+		output = new MockWritable();
+		input = new MockReadable();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		updateSettings({ withGuide: true });
+	});
+
+	test('renders message with options', async () => {
+		const result = prompts.selectKey({
+			message: 'foo',
+			options: [
+				{ label: 'Option A', value: 'a' },
+				{ label: 'Option B', value: 'b' },
+			],
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe(undefined);
+	});
+
+	test('selects option by keypress', async () => {
+		const result = prompts.selectKey({
+			message: 'foo',
+			options: [
+				{ label: 'Option A', value: 'a' },
+				{ label: 'Option B', value: 'b' },
+			],
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'b', { name: 'b' });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe('b');
+	});
+
+	test('can cancel by pressing escape', async () => {
+		const result = prompts.selectKey({
+			message: 'foo',
+			options: [
+				{ label: 'Option A', value: 'a' },
+				{ label: 'Option B', value: 'b' },
+			],
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'escape', { name: 'escape' });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(prompts.isCancel(value)).toBe(true);
+	});
+
+	test('options are case-insensitive by default', async () => {
+		const result = prompts.selectKey({
+			message: 'foo',
+			options: [
+				{ label: 'Option A', value: 'A' },
+				{ label: 'Option B', value: 'b' },
+			],
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'a', { name: 'a' });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe('A');
+	});
+
+	test('input is case-insensitive by default', async () => {
+		const result = prompts.selectKey({
+			message: 'foo',
+			options: [
+				{ label: 'Option A', value: 'a' },
+				{ label: 'Option B', value: 'b' },
+			],
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'a', { name: 'a', shift: true });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe('a');
+	});
+
+	test('caseSensitive: true makes options case-sensitive', async () => {
+		const result = prompts.selectKey({
+			message: 'foo',
+			options: [
+				{ label: 'Option A', value: 'A' },
+				{ label: 'Option B', value: 'b' },
+			],
+			caseSensitive: true,
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'a', { name: 'a' });
+		input.emit('keypress', '', { name: 'escape' });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(prompts.isCancel(value)).toBe(true);
+	});
+
+	test('caseSensitive: true makes input case-sensitive', async () => {
+		const result = prompts.selectKey({
+			message: 'foo',
+			options: [
+				{ label: 'Option a', value: 'a' },
+				{ label: 'Option A', value: 'A' },
+				{ label: 'Option B', value: 'b' },
+			],
+			caseSensitive: true,
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'a', { name: 'a', shift: true });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe('A');
+	});
+
+	test('long option labels are wrapped correctly', async () => {
+		output.columns = 40;
+
+		const result = prompts.selectKey({
+			message: 'Select an option:',
+			options: [
+				{
+					label: 'This is a somewhat long label '.repeat(10).trimEnd(),
+					value: 'a',
+				},
+				{ label: 'Short label', value: 'b' },
+			],
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'a', { name: 'a' });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe('a');
+	});
+
+	test('long cancelled labels are wrapped correctly', async () => {
+		output.columns = 40;
+
+		const result = prompts.selectKey({
+			message: 'Select an option:',
+			options: [
+				{
+					label: 'This is a somewhat long label '.repeat(10).trimEnd(),
+					value: 'a',
+				},
+				{ label: 'Short label', value: 'b' },
+			],
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'escape' });
+
+		await result;
+
+		expect(output.buffer).toMatchSnapshot();
+	});
+
+	test('long submitted labels are wrapped correctly', async () => {
+		output.columns = 40;
+
+		const result = prompts.selectKey({
+			message: 'Select an option:',
+			options: [
+				{
+					label: 'This is a somewhat long label '.repeat(10).trimEnd(),
+					value: 'a',
+				},
+				{ label: 'Short label', value: 'b' },
+			],
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'a', { name: 'a' });
+
+		await result;
+
+		expect(output.buffer).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
Adds a new `caseSensitive` option such that you can bind to uppercase
keys.

Also fixes a bunch of line-wrapping render bugs and adds a test suite.

Fixes #435.
