### PR TITLE
chore(prompts): simplify guide option checks

### DIFF
--- a/.changeset/five-places-shake.md
+++ b/.changeset/five-places-shake.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+chore: simplify guide option checks

--- a/packages/prompts/src/box.ts
+++ b/packages/prompts/src/box.ts
@@ -67,7 +67,7 @@ export const box = (message = '', title = '', opts?: BoxOptions) => {
 	const titlePadding = opts?.titlePadding ?? 1;
 	const contentPadding = opts?.contentPadding ?? 2;
 	const width = opts?.width === undefined || opts.width === 'auto' ? 1 : Math.min(1, opts.width);
-	const hasGuide = (opts?.withGuide ?? settings.withGuide) !== false;
+	const hasGuide = opts?.withGuide ?? settings.withGuide;
 	const linePrefix = !hasGuide ? '' : `${S_BAR} `;
 	const formatBorder = opts?.formatBorder ?? defaultFormatBorder;
 	const symbols = (opts?.rounded ? roundedSymbols : squareSymbols).map(formatBorder);

--- a/packages/prompts/src/log.ts
+++ b/packages/prompts/src/log.ts
@@ -28,7 +28,7 @@ export const log = {
 		}: LogMessageOptions = {}
 	) => {
 		const parts: string[] = [];
-		const hasGuide = (withGuide ?? settings.withGuide) !== false;
+		const hasGuide = withGuide ?? settings.withGuide;
 		const spacingString = !hasGuide ? '' : secondarySymbol;
 		const prefix = !hasGuide ? '' : `${symbol}  `;
 		const secondaryPrefix = !hasGuide ? '' : `${secondarySymbol}  `;

--- a/packages/prompts/src/note.ts
+++ b/packages/prompts/src/note.ts
@@ -36,7 +36,7 @@ const wrapWithFormat = (message: string, width: number, format: FormatFn): strin
 
 export const note = (message = '', title = '', opts?: NoteOptions) => {
 	const output: Writable = opts?.output ?? process.stdout;
-	const hasGuide = (opts?.withGuide ?? settings.withGuide) !== false;
+	const hasGuide = opts?.withGuide ?? settings.withGuide;
 	const format = opts?.format ?? defaultNoteFormatter;
 	const wrapMsg = wrapWithFormat(message, getColumns(output) - 6, format);
 	const lines = ['', ...wrapMsg.split('\n').map(format), ''];

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -16,7 +16,7 @@ export const password = (opts: PasswordOptions) => {
 		input: opts.input,
 		output: opts.output,
 		render() {
-			const hasGuide = (opts.withGuide ?? settings.withGuide) !== false;
+			const hasGuide = opts.withGuide ?? settings.withGuide;
 			const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
 			const userInput = this.userInputWithCursor;
 			const masked = this.masked;

--- a/packages/prompts/src/select-key.ts
+++ b/packages/prompts/src/select-key.ts
@@ -40,7 +40,7 @@ export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) =
 		initialValue: opts.initialValue,
 		caseSensitive: opts.caseSensitive,
 		render() {
-			const hasGuide = (opts.withGuide ?? settings.withGuide) !== false;
+			const hasGuide = opts.withGuide ?? settings.withGuide;
 			const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
 
 			switch (this.state) {

--- a/packages/prompts/src/select.ts
+++ b/packages/prompts/src/select.ts
@@ -113,7 +113,7 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 		output: opts.output,
 		initialValue: opts.initialValue,
 		render() {
-			const hasGuide = (opts.withGuide ?? settings.withGuide) !== false;
+			const hasGuide = opts.withGuide ?? settings.withGuide;
 			const titlePrefix = `${symbol(this.state)}  `;
 			const titlePrefixBar = `${symbolBar(this.state)}  `;
 			const messageLines = wrapTextWithPrefix(

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -127,7 +127,7 @@ export const spinner = ({
 		return min > 0 ? `[${min}m ${secs}s]` : `[${secs}s]`;
 	};
 
-	const hasGuide = (opts.withGuide ?? settings.withGuide) !== false;
+	const hasGuide = opts.withGuide ?? settings.withGuide;
 
 	const start = (msg = ''): void => {
 		isSpinnerActive = true;

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -20,7 +20,7 @@ export const text = (opts: TextOptions) => {
 		signal: opts.signal,
 		input: opts.input,
 		render() {
-			const hasGuide = (opts?.withGuide ?? settings.withGuide) !== false;
+			const hasGuide = opts?.withGuide ?? settings.withGuide;
 			const titlePrefix = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)}  `;
 			const title = `${titlePrefix}${opts.message}\n`;
 			const placeholder = opts.placeholder


### PR DESCRIPTION
# Why

While looking at code to see what changes would need to be needed to address the inconsistence spacing with `withGuide: false` option reported earlier today I have spotted that checks for that options in code can be simplified.

# How

`opts.withGuide` can be `boolean` or `undefined`, while global setting can only be a `boolean` so checking against raw `false` value in this case is redundant.