### PR TITLE
fix(prompts): honor withGuide for intro/outro/cancel messages

### DIFF
--- a/.changeset/quiet-experts-itch.md
+++ b/.changeset/quiet-experts-itch.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fixes withGuide support in intro, outro, and cancel messages.

--- a/packages/prompts/src/messages.ts
+++ b/packages/prompts/src/messages.ts
@@ -1,18 +1,25 @@
 import type { Writable } from 'node:stream';
 import { styleText } from 'node:util';
+import { settings } from '@clack/core';
 import { type CommonOptions, S_BAR, S_BAR_END, S_BAR_START } from './common.js';
 
 export const cancel = (message = '', opts?: CommonOptions) => {
 	const output: Writable = opts?.output ?? process.stdout;
-	output.write(`${styleText('gray', S_BAR_END)}  ${styleText('red', message)}\n\n`);
+	const hasGuide = opts?.withGuide ?? settings.withGuide;
+	const prefix = hasGuide ? `${styleText('gray', S_BAR_END)}  ` : '';
+	output.write(`${prefix}${styleText('red', message)}\n\n`);
 };
 
 export const intro = (title = '', opts?: CommonOptions) => {
 	const output: Writable = opts?.output ?? process.stdout;
-	output.write(`${styleText('gray', S_BAR_START)}  ${title}\n`);
+	const hasGuide = opts?.withGuide ?? settings.withGuide;
+	const prefix = hasGuide ? `${styleText('gray', S_BAR_START)}  ` : '';
+	output.write(`${prefix}${title}\n`);
 };
 
 export const outro = (message = '', opts?: CommonOptions) => {
 	const output: Writable = opts?.output ?? process.stdout;
-	output.write(`${styleText('gray', S_BAR)}\n${styleText('gray', S_BAR_END)}  ${message}\n\n`);
+	const hasGuide = opts?.withGuide ?? settings.withGuide;
+	const prefix = hasGuide ? `${styleText('gray', S_BAR)}\n${styleText('gray', S_BAR_END)}  ` : '';
+	output.write(`${prefix}${message}\n\n`);
 };


### PR DESCRIPTION
Fixes @clack/prompts message helpers (intro, outro, cancel) to consistently respect withGuide/settings.withGuide when rendering guide bars