### PR TITLE
feat(autocomplete): do not set default filter for options getters

### DIFF
--- a/.changeset/silent-sides-call.md
+++ b/.changeset/silent-sides-call.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": patch
+---
+
+Only apply autocomplete default filter if it has been explicitly set or if options is not a getter.

--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -71,7 +71,7 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 	focusedValue: T['value'] | undefined;
 	#cursor = 0;
 	#lastUserInput = '';
-	#filterFn: FilterFunction<T>;
+	#filterFn: FilterFunction<T> | undefined;
 	#options: T[] | (() => T[]);
 	#placeholder: string | undefined;
 
@@ -106,7 +106,8 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 		const options = this.options;
 		this.filteredOptions = [...options];
 		this.multiple = opts.multiple === true;
-		this.#filterFn = opts.filter ?? defaultFilter;
+		this.#filterFn =
+			typeof opts.options === 'function' ? opts.filter : (opts.filter ?? defaultFilter);
 		let initialValues: unknown[] | undefined;
 		if (opts.initialValue && Array.isArray(opts.initialValue)) {
 			if (this.multiple) {
@@ -160,7 +161,9 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 		const placeholderMatchesOption =
 			placeholder !== undefined &&
 			placeholder !== '' &&
-			options.some((opt) => !opt.disabled && this.#filterFn(placeholder, opt));
+			options.some(
+				(opt) => !opt.disabled && (this.#filterFn ? this.#filterFn(placeholder, opt) : true)
+			);
 		if (key.name === 'tab' && isEmptyOrOnlyTab && placeholderMatchesOption) {
 			if (this.userInput === '\t') {
 				this._clearUserInput();
@@ -225,8 +228,8 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 
 			const options = this.options;
 
-			if (value) {
-				this.filteredOptions = options.filter((opt) => this.#filterFn(value, opt));
+			if (value && this.#filterFn) {
+				this.filteredOptions = options.filter((opt) => this.#filterFn?.(value, opt));
 			} else {
 				this.filteredOptions = [...options];
 			}

--- a/packages/core/test/prompts/autocomplete.test.ts
+++ b/packages/core/test/prompts/autocomplete.test.ts
@@ -216,6 +216,47 @@ describe('AutocompletePrompt', () => {
 		expect(result).to.equal('apple');
 	});
 
+	test('options as function skips default filter', () => {
+		const dynamicOptions = [
+			{ value: 'apple', label: 'Apple' },
+			{ value: 'banana', label: 'Banana' },
+		];
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: () => dynamicOptions,
+		});
+
+		instance.prompt();
+
+		input.emit('keypress', 'z', { name: 'z' });
+
+		expect(instance.filteredOptions).toEqual(dynamicOptions);
+	});
+
+	test('options as function applies user-provided filter', () => {
+		const dynamicOptions = [
+			{ value: 'apple', label: 'Apple' },
+			{ value: 'banana', label: 'Banana' },
+			{ value: 'cherry', label: 'Cherry' },
+		];
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: () => dynamicOptions,
+			filter: (search, opt) => (opt.label ?? '').toLowerCase().endsWith(search.toLowerCase()),
+		});
+
+		instance.prompt();
+
+		input.emit('keypress', 'a', { name: 'a' });
+
+		// 'endsWith' matches Banana but not Apple or Cherry
+		expect(instance.filteredOptions).toEqual([{ value: 'banana', label: 'Banana' }]);
+	});
+
 	test('Tab with non-matching placeholder does not fill input', async () => {
 		const instance = new AutocompletePrompt({
 			input,


### PR DESCRIPTION
Basically:

- If `options` is a function, do not set the default filter
- If a filter is explicitly set, keep it
- If `options` is not a function, set the default filter

Closes #488.
Closes #489.


