### PR TITLE
chore: remove unused debug key

### DIFF
--- a/.changeset/afraid-pets-notice.md
+++ b/.changeset/afraid-pets-notice.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": minor
+---
+
+Remove unused `debug` option key.

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -21,7 +21,6 @@ export interface PromptOptions<TValue, Self extends Prompt<TValue>> {
 	validate?: ((value: TValue | undefined) => string | Error | undefined) | undefined;
 	input?: Readable;
 	output?: Writable;
-	debug?: boolean;
 	signal?: AbortSignal;
 }
 


### PR DESCRIPTION
`debug` is unused (maybe), so i remove it.
