### PR TITLE
Correct Progress example in README

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -262,7 +262,7 @@ p.start('Downloading archive');
 // Do download here
 p.advance(3, 'Downloading (30%)');
 // ...
-p.advance(8, 'Downloading (80%)');
+p.advance(5, 'Downloading (80%)');
 // ...
 p.stop('Archive downloaded');
 ```


### PR DESCRIPTION
The progress example used `progress.advance` as if it was setting the progress amount. When in fact, it advances the progress amount forward by the given amount. This small correction I hope will make this distinction more obvious to future readers.