### PR TITLE
fix(@clack/prompts): handle carriage return output in taskLog

### DIFF
--- a/.changeset/lovely-radios-joke.md
+++ b/.changeset/lovely-radios-joke.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fix `taskLog` raw message handling so carriage-return spinner updates do not accumulate repeated frames.

--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -59,6 +59,13 @@ const appendRawMessage = (input: string, msg: string, prependNewline: boolean): 
 	return next;
 };
 
+const collapseCarriageReturnUpdates = (input: string): string => {
+	return input
+		.split('\n')
+		.map((line) => line.slice(line.lastIndexOf('\r') + 1))
+		.join('\n');
+};
+
 /**
  * Renders a log which clears on success and remains on failure
  */
@@ -170,7 +177,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 			if (buffer.value !== '') {
 				buffer.value += '\n';
 			}
-			buffer.value += sanitized;
+			buffer.value += collapseCarriageReturnUpdates(sanitized);
 			lastMessageWasRaw = false;
 		}
 		if (opts.limit !== undefined) {

--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -41,6 +41,24 @@ const stripDestructiveANSI = (input: string): string => {
 	return input.replace(/\x1b\[(?:\d+;)*\d*[ABCDEFGHfJKSTsu]|\x1b\[(s|u)/g, '');
 };
 
+const replaceLastLine = (input: string, replacement: string): string => {
+	const lastNewline = input.lastIndexOf('\n');
+	if (lastNewline === -1) {
+		return replacement;
+	}
+	return `${input.slice(0, lastNewline + 1)}${replacement}`;
+};
+
+const appendRawMessage = (input: string, msg: string, prependNewline: boolean): string => {
+	let next = prependNewline ? `${input}\n` : input;
+	const [first, ...overwrites] = msg.split('\r');
+	next += first;
+	for (const overwrite of overwrites) {
+		next = replaceLastLine(next, overwrite);
+	}
+	return next;
+};
+
 /**
  * Renders a log which clears on success and remains on failure
  */
@@ -139,11 +157,22 @@ export const taskLog = (opts: TaskLogOptions) => {
 	};
 	const message = (buffer: BufferEntry, msg: string, mopts?: TaskLogMessageOptions) => {
 		clear(false);
-		if ((mopts?.raw !== true || !lastMessageWasRaw) && buffer.value !== '') {
-			buffer.value += '\n';
+		const sanitized = stripDestructiveANSI(msg);
+		if (mopts?.raw === true) {
+			const rawMessage = sanitized.replace(/\n+$/g, '');
+			buffer.value = appendRawMessage(
+				buffer.value,
+				rawMessage,
+				buffer.value !== '' && !lastMessageWasRaw && !rawMessage.startsWith('\n') && !rawMessage.startsWith('\r')
+			);
+			lastMessageWasRaw = !sanitized.endsWith('\n');
+		} else {
+			if (buffer.value !== '') {
+				buffer.value += '\n';
+			}
+			buffer.value += sanitized;
+			lastMessageWasRaw = false;
 		}
-		buffer.value += stripDestructiveANSI(msg);
-		lastMessageWasRaw = mopts?.raw === true;
 		if (opts.limit !== undefined) {
 			const lines = buffer.value.split('\n');
 			const linesToRemove = lines.length - opts.limit;

--- a/packages/prompts/test/__snapshots__/task-log.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/task-log.test.ts.snap
@@ -1,5 +1,28 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`taskLog (isCI = false) > error > clears carriage return spinner line when showLog = false 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  foo
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [2m◒  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2m◐  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2m◓  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m
+[31m■[39m  some error!
+",
+]
+`;
+
 exports[`taskLog (isCI = false) > error > clears output if showLog = false 1`] = `
 [
   "[90m│[39m
@@ -17,6 +40,32 @@ exports[`taskLog (isCI = false) > error > clears output if showLog = false 1`] =
   "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
   "[90m│[39m
 [31m■[39m  some error!
+",
+]
+`;
+
+exports[`taskLog (isCI = false) > error > renders latest carriage return spinner line with error 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  foo
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [2m◒  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2m◐  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2m◓  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m
+[31m■[39m  some error!
+",
+  "[90m│[39m
+[90m│[39m  [2m◓  Cloning repository[22m
 ",
 ]
 `;
@@ -712,6 +761,28 @@ exports[`taskLog (isCI = false) > message > raw = true appends message text unti
 ]
 `;
 
+exports[`taskLog (isCI = false) > message > raw = true replaces carriage return spinner updates 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  foo
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [2m◒  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2m◐  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2m◓  Cloning repository[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [2m◇  Repository cloned[22m
+",
+]
+`;
+
 exports[`taskLog (isCI = false) > message > raw = true works when mixed with non-raw messages 1`] = `
 [
   "[90m│[39m
@@ -1164,6 +1235,23 @@ exports[`taskLog (isCI = false) > writes message header 1`] = `
 ]
 `;
 
+exports[`taskLog (isCI = true) > error > clears carriage return spinner line when showLog = false 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  foo
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m
+[31m■[39m  some error!
+",
+]
+`;
+
 exports[`taskLog (isCI = true) > error > clears output if showLog = false 1`] = `
 [
   "[90m│[39m
@@ -1176,6 +1264,26 @@ exports[`taskLog (isCI = true) > error > clears output if showLog = false 1`] = 
   "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
   "[90m│[39m
 [31m■[39m  some error!
+",
+]
+`;
+
+exports[`taskLog (isCI = true) > error > renders latest carriage return spinner line with error 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  foo
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m
+[31m■[39m  some error!
+",
+  "[90m│[39m
+[90m│[39m  [2m◓  Cloning repository[22m
 ",
 ]
 `;
@@ -1427,6 +1535,20 @@ exports[`taskLog (isCI = true) > message > raw = true appends message text until
 ",
   "[90m│[39m
 ",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > message > raw = true replaces carriage return spinner updates 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  foo
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
   "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
   "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
 ]

--- a/packages/prompts/test/task-log.test.ts
+++ b/packages/prompts/test/task-log.test.ts
@@ -134,6 +134,23 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 			expect(output.buffer).toMatchSnapshot();
 		});
 
+		test('raw = false keeps only the last carriage return update when success shows the log', async () => {
+			const log = prompts.taskLog({
+				input,
+				output,
+				title: 'foo',
+			});
+
+			log.message('◒  Cloning repository\r◐  Cloning repository\r◓  Cloning repository\r◇  Repository cloned');
+			log.success('done!', { showLog: true });
+
+			const renderedLog = output.buffer.at(-1);
+			expect(renderedLog).toContain('◇  Repository cloned');
+			expect(renderedLog).not.toContain('◒  Cloning repository');
+			expect(renderedLog).not.toContain('◐  Cloning repository');
+			expect(renderedLog).not.toContain('◓  Cloning repository');
+		});
+
 		test('prints empty lines', async () => {
 			const log = prompts.taskLog({
 				input,
@@ -224,6 +241,24 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 			log.error('some error!', { showLog: false });
 
 			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('raw = false keeps only the last carriage return update on error', () => {
+			const log = prompts.taskLog({
+				input,
+				output,
+				title: 'foo',
+			});
+
+			log.message('◒  Cloning repository\r◐  Cloning repository\r◓  Cloning repository\r◇  Repository cloned');
+
+			log.error('some error!');
+
+			const renderedLog = output.buffer.at(-1);
+			expect(renderedLog).toContain('◇  Repository cloned');
+			expect(renderedLog).not.toContain('◒  Cloning repository');
+			expect(renderedLog).not.toContain('◐  Cloning repository');
+			expect(renderedLog).not.toContain('◓  Cloning repository');
 		});
 	});
 

--- a/packages/prompts/test/task-log.test.ts
+++ b/packages/prompts/test/task-log.test.ts
@@ -119,6 +119,21 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 			expect(output.buffer).toMatchSnapshot();
 		});
 
+		test('raw = true replaces carriage return spinner updates', async () => {
+			const log = prompts.taskLog({
+				input,
+				output,
+				title: 'foo',
+			});
+
+			log.message('◒  Cloning repository', { raw: true });
+			log.message('\r◐  Cloning repository', { raw: true });
+			log.message('\r◓  Cloning repository', { raw: true });
+			log.message('\r◇  Repository cloned\n', { raw: true });
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
 		test('prints empty lines', async () => {
 			const log = prompts.taskLog({
 				input,
@@ -173,6 +188,38 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 
 			log.message('line 0');
 			log.message('line 1');
+
+			log.error('some error!', { showLog: false });
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('renders latest carriage return spinner line with error', () => {
+			const log = prompts.taskLog({
+				input,
+				output,
+				title: 'foo',
+			});
+
+			log.message('◒  Cloning repository', { raw: true });
+			log.message('\r◐  Cloning repository', { raw: true });
+			log.message('\r◓  Cloning repository', { raw: true });
+
+			log.error('some error!');
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('clears carriage return spinner line when showLog = false', () => {
+			const log = prompts.taskLog({
+				input,
+				output,
+				title: 'foo',
+			});
+
+			log.message('◒  Cloning repository', { raw: true });
+			log.message('\r◐  Cloning repository', { raw: true });
+			log.message('\r◓  Cloning repository', { raw: true });
 
 			log.error('some error!', { showLog: false });
 


### PR DESCRIPTION
## Summary
- handle `taskLog` raw message updates that use carriage returns so spinner frames do not accumulate
- add regression coverage for carriage-return spinner output and `error()` rendering behavior
- add a changeset for the `@clack/prompts` patch release

## Test Plan
- `cd packages/prompts && pnpm test`