### PR TITLE
feat(core): support number key jump in select prompt

### DIFF
--- a/.changeset/clever-tigers-jump.md
+++ b/.changeset/clever-tigers-jump.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": minor
+---
+
+Press number keys 1–9 in the select prompt to jump to the corresponding option.

--- a/packages/core/src/prompts/select.ts
+++ b/packages/core/src/prompts/select.ts
@@ -43,5 +43,15 @@ export default class SelectPrompt<T extends { value: any; disabled?: boolean }> 
 			}
 			this.changeValue();
 		});
+
+		this.on('key', (char, key) => {
+			if (key.ctrl || key.meta) return;
+			if (!char || char.length !== 1) return;
+			if (char < '1' || char > '9') return;
+			const target = Number(char) - 1;
+			if (target >= this.options.length) return;
+			this.cursor = this.options[target].disabled ? findCursor<T>(target, 1, this.options) : target;
+			this.changeValue();
+		});
 	}
 }

--- a/packages/core/test/prompts/select.test.ts
+++ b/packages/core/test/prompts/select.test.ts
@@ -138,5 +138,41 @@ describe('SelectPrompt', () => {
 			instance.prompt();
 			expect(instance.cursor).to.equal(1);
 		});
+
+		test('number key jumps to option', () => {
+			const instance = new SelectPrompt({
+				input,
+				output,
+				render: () => 'foo',
+				options: [{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }],
+			});
+			instance.prompt();
+			input.emit('keypress', '3', { name: '3' });
+			expect(instance.cursor).to.equal(2);
+		});
+
+		test('number key skips disabled option', () => {
+			const instance = new SelectPrompt({
+				input,
+				output,
+				render: () => 'foo',
+				options: [{ value: 'foo' }, { value: 'bar', disabled: true }, { value: 'baz' }],
+			});
+			instance.prompt();
+			input.emit('keypress', '2', { name: '2' });
+			expect(instance.cursor).to.equal(2);
+		});
+
+		test('out-of-range number key is ignored', () => {
+			const instance = new SelectPrompt({
+				input,
+				output,
+				render: () => 'foo',
+				options: [{ value: 'foo' }, { value: 'bar' }],
+			});
+			instance.prompt();
+			input.emit('keypress', '9', { name: '9' });
+			expect(instance.cursor).to.equal(0);
+		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Press keys 1–9 in the select prompt to jump the cursor to that option. Out-of-range digits are ignored; if the target is disabled, the cursor skips forward to the next enabled option (same as the down-arrow). Enter still submits.

Closes #475 

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code
