### PR TITLE
chore: add engines field to prompts and core

### DIFF
--- a/.changeset/mean-squids-slide.md
+++ b/.changeset/mean-squids-slide.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": minor
+"@clack/core": minor
+---
+
+fix: add engines field expressing node >=20.12 requirement

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,9 @@
   },
   "license": "MIT",
   "packageManager": "pnpm@9.14.2",
+  "engines": {
+    "node": ">= 20.12.0"
+  },
   "scripts": {
     "build": "unbuild",
     "prepack": "pnpm build",

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -47,6 +47,9 @@
     "ui"
   ],
   "packageManager": "pnpm@9.14.2",
+  "engines": {
+    "node": ">= 20.12.0"
+  },
   "scripts": {
     "build": "unbuild",
     "prepack": "pnpm build",


### PR DESCRIPTION
## What does this PR do?

<!--
  Describe the change and why it's needed. Link to a related issue or discussion.
  If there is no issue, please explain why one isn't needed.
-->

I noticed there was no explicit engines field, however from what I can tell at this seems to be the minimum version of node that you need to run Clack, as that was when [util.styleText](https://nodejs.org/docs/latest-v20.x/api/util.html#utilstyletextformat-text-options) was added. I did put the changeset as a minor though to be safer, but we likely could just have it as a patch

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
