### PR TITLE
fix: split type-only and runtime exports

### DIFF
--- a/.changeset/honest-crews-go.md
+++ b/.changeset/honest-crews-go.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fix mixed type-only and runtime exports from @clack/core.

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1,4 +1,5 @@
-export { type ClackSettings, isCancel, settings, updateSettings } from '@clack/core';
+export type { ClackSettings } from '@clack/core';
+export { isCancel, settings, updateSettings } from '@clack/core';
 
 export * from './autocomplete.js';
 export * from './box.js';


### PR DESCRIPTION
## Summary

Splits the mixed type/value re-export from `@clack/core` into separate type-only and runtime exports.

This avoids runtime exports such as `isCancel`, `settings`, and `updateSettings` being dropped by some TypeScript emitters or bundlers.

Closes #470

## Testing

- `pnpm build`
- `pnpm types`

No tests were added because this only separates type-only and runtime re-exports.