### PR TITLE
feat(prompts): support maxItems in groupMultiselect

### DIFF
--- a/.changeset/tame-beds-kiss.md
+++ b/.changeset/tame-beds-kiss.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": minor
+---
+
+Support scrolling and `maxItems` option for `groupMultiselect`, and removes indent when `withGuide` is set to `false`

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -9,12 +9,14 @@ import {
 	S_CHECKBOX_SELECTED,
 	symbol,
 } from './common.js';
+import { limitOptions } from './limit-options.js';
 import type { Option } from './select.js';
 
 export interface GroupMultiSelectOptions<Value> extends CommonOptions {
 	message: string;
 	options: Record<string, Option<Value>[]>;
 	initialValues?: Value[];
+	maxItems?: number;
 	required?: boolean;
 	cursorAt?: Value;
 	selectableGroups?: boolean;
@@ -42,8 +44,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 		const prefix = isItem ? (selectableGroups ? `${isLast ? S_BAR_END : S_BAR} ` : '  ') : '';
 		let spacingPrefix = '';
 		if (groupSpacing > 0 && !isItem) {
-			const spacingPrefixText = `\n${styleText('cyan', S_BAR)}`;
-			spacingPrefix = `${spacingPrefixText.repeat(groupSpacing - 1)}${spacingPrefixText}  `;
+			spacingPrefix = '\n'.repeat(groupSpacing);
 		}
 
 		if (state === 'active') {
@@ -108,6 +109,30 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 			const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
 			const value = this.value ?? [];
 
+			const styleOption = (
+				option: Option<Value> & { group: string | boolean },
+				active: boolean
+			) => {
+				const options = this.options;
+				const selected =
+					value.includes(option.value) ||
+					(option.group === true && this.isGroupSelected(`${option.value}`));
+				const groupActive =
+					!active &&
+					typeof option.group === 'string' &&
+					this.options[this.cursor].value === option.group;
+				if (groupActive) {
+					return opt(option, selected ? 'group-active-selected' : 'group-active', options);
+				}
+				if (active && selected) {
+					return opt(option, 'active-selected', options);
+				}
+				if (selected) {
+					return opt(option, 'selected', options);
+				}
+				return opt(option, active ? 'active' : 'inactive', options);
+			};
+
 			switch (this.state) {
 				case 'submit': {
 					const selectedOptions = this.options
@@ -127,6 +152,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 					}`;
 				}
 				case 'error': {
+					const guidePrefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
 					const footer = this.error
 						.split('\n')
 						.map((ln, i) =>
@@ -135,60 +161,35 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 								: `   ${ln}`
 						)
 						.join('\n');
-					return `${title}${hasGuide ? `${styleText('yellow', S_BAR)}  ` : ''}${this.options
-						.map((option, i, options) => {
-							const selected =
-								value.includes(option.value) ||
-								(option.group === true && this.isGroupSelected(`${option.value}`));
-							const active = i === this.cursor;
-							const groupActive =
-								!active &&
-								typeof option.group === 'string' &&
-								this.options[this.cursor].value === option.group;
-							if (groupActive) {
-								return opt(option, selected ? 'group-active-selected' : 'group-active', options);
-							}
-							if (active && selected) {
-								return opt(option, 'active-selected', options);
-							}
-							if (selected) {
-								return opt(option, 'selected', options);
-							}
-							return opt(option, active ? 'active' : 'inactive', options);
-						})
-						.join(`\n${hasGuide ? `${styleText('yellow', S_BAR)}  ` : ''}`)}\n${footer}\n`;
+					// Calculate rowPadding: title lines + footer lines (error message + trailing newline)
+					const titleLineCount = title.split('\n').length;
+					const footerLineCount = footer.split('\n').length + 1; // footer + trailing newline
+					const optionsText = limitOptions({
+						output: opts.output,
+						options: this.options,
+						cursor: this.cursor,
+						maxItems: opts.maxItems,
+						columnPadding: guidePrefix.length,
+						rowPadding: titleLineCount + footerLineCount,
+						style: styleOption,
+					}).join(`\n${guidePrefix}`);
+					return `${title}${guidePrefix}${optionsText}\n${footer}\n`;
 				}
 				default: {
-					const optionsText = this.options
-						.map((option, i, options) => {
-							const selected =
-								value.includes(option.value) ||
-								(option.group === true && this.isGroupSelected(`${option.value}`));
-							const active = i === this.cursor;
-							const groupActive =
-								!active &&
-								typeof option.group === 'string' &&
-								this.options[this.cursor].value === option.group;
-							let optionText = '';
-							if (groupActive) {
-								optionText = opt(
-									option,
-									selected ? 'group-active-selected' : 'group-active',
-									options
-								);
-							} else if (active && selected) {
-								optionText = opt(option, 'active-selected', options);
-							} else if (selected) {
-								optionText = opt(option, 'selected', options);
-							} else {
-								optionText = opt(option, active ? 'active' : 'inactive', options);
-							}
-							const prefix = i !== 0 && !optionText.startsWith('\n') ? '  ' : '';
-							return `${prefix}${optionText}`;
-						})
-						.join(`\n${hasGuide ? styleText('cyan', S_BAR) : ''}`);
-					const optionsPrefix = optionsText.startsWith('\n') ? '' : '  ';
-					return `${title}${hasGuide ? styleText('cyan', S_BAR) : ''}${optionsPrefix}${optionsText}\n${
+					const guidePrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+					// Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
+					const titleLineCount = title.split('\n').length;
+					const footerLineCount = (hasGuide ? 1 : 0) + 1; // guide line + trailing newline
+					const optionsText = limitOptions({
+						output: opts.output,
+						options: this.options,
+						cursor: this.cursor,
+						maxItems: opts.maxItems,
+						columnPadding: guidePrefix.length,
+						rowPadding: titleLineCount + footerLineCount,
+						style: styleOption,
+					}).join(`\n${guidePrefix}`);
+					return `${title}${guidePrefix}${optionsText}\n${
 						hasGuide ? styleText('cyan', S_BAR_END) : ''
 					}\n`;
 				}

--- a/packages/prompts/test/__snapshots__/group-multi-select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/group-multi-select.test.ts.snap
@@ -252,23 +252,23 @@ exports[`groupMultiselect (isCI = false) > global withGuide: false removes guide
 [
   "<cursor.hide>",
   "[36m◆[39m  foo
-  [2m[22m[36m◻[39m group1
-  │ [36m◻[39m [2mgroup1value0[22m
-  └ [36m◻[39m [2mgroup1value1[22m
+[2m[22m[36m◻[39m group1
+│ [36m◻[39m [2mgroup1value0[22m
+└ [36m◻[39m [2mgroup1value1[22m
 
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "  [2m[22m[2m◻[22m [2mgroup1[22m
-  [2m│ [22m[36m◻[39m group1value0
-  [2m└ [22m[2m◻[22m [2mgroup1value1[22m
+  "[2m[22m[2m◻[22m [2mgroup1[22m
+[2m│ [22m[36m◻[39m group1value0
+[2m└ [22m[2m◻[22m [2mgroup1value1[22m
 
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "  [2m│ [22m[32m◼[39m group1value0",
+  "[2m│ [22m[32m◼[39m group1value0",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=5>",
   "<erase.down>",
@@ -325,12 +325,12 @@ exports[`groupMultiselect (isCI = false) > groupSpacing > renders spaced groups 
   "<cursor.hide>",
   "[90m│[39m
 [36m◆[39m  foo
-[36m│[39m
-[36m│[39m
+[36m│[39m  
+[36m│[39m  
 [36m│[39m  [2m[22m[36m◻[39m group1
 [36m│[39m  └ [36m◻[39m [2mgroup1value0[22m
-[36m│[39m
-[36m│[39m
+[36m│[39m  
+[36m│[39m  
 [36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
 [36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
 [36m└[39m
@@ -340,8 +340,8 @@ exports[`groupMultiselect (isCI = false) > groupSpacing > renders spaced groups 
   "<erase.down>",
   "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
 [36m│[39m  [2m└ [22m[36m◻[39m group1value0
-[36m│[39m
-[36m│[39m
+[36m│[39m  
+[36m│[39m  
 [36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
 [36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
 [36m└[39m
@@ -351,8 +351,8 @@ exports[`groupMultiselect (isCI = false) > groupSpacing > renders spaced groups 
   "<erase.down>",
   "[36m│[39m  [2m[22m[32m◼[39m [2mgroup1[22m
 [36m│[39m  [2m└ [22m[32m◼[39m group1value0
-[36m│[39m
-[36m│[39m
+[36m│[39m  
+[36m│[39m  
 [36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
 [36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
 [36m└[39m
@@ -383,6 +383,96 @@ exports[`groupMultiselect (isCI = false) > initial values can be set 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mgroup1value1[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`groupMultiselect (isCI = false) > maxItems renders a sliding window 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value2[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value0
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value0[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value1
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value2
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m...[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value3
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value4
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value5[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group1value5
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=5>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2m└ [22m[32m◼[39m group1value5",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup1value5[22m",
   "
 ",
   "<cursor.show>",
@@ -536,6 +626,223 @@ exports[`groupMultiselect (isCI = false) > selectableGroups = false > selecting 
 ]
 `;
 
+exports[`groupMultiselect (isCI = false) > sliding window loops downwards 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value2[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value0
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value0[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value1
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value2
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m...[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value3
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value4
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value5[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group1value5
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value5[22m
+[36m│[39m  [2m[22m[36m◻[39m group2
+[36m│[39m  │ [36m◻[39m [2mgroup2value0[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value5[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value0
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value1[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value0[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value1
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value2[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value0[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value2
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value2[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value3
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value4[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value5[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=5>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value3[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value4
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value5[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=6>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value4[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group2value5
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value2[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value0
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2m│ [22m[32m◼[39m group1value0",
+  "<cursor.down count=6>",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup1value0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`groupMultiselect (isCI = false) > sliding window loops upwards 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value2[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m...[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value3[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value4[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group2value5
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=7>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2m└ [22m[32m◼[39m group2value5",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup2value5[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`groupMultiselect (isCI = false) > values can be non-primitive 1`] = `
 [
   "<cursor.hide>",
@@ -574,23 +881,23 @@ exports[`groupMultiselect (isCI = false) > withGuide: false removes guide 1`] = 
 [
   "<cursor.hide>",
   "[36m◆[39m  foo
-  [2m[22m[36m◻[39m group1
-  │ [36m◻[39m [2mgroup1value0[22m
-  └ [36m◻[39m [2mgroup1value1[22m
+[2m[22m[36m◻[39m group1
+│ [36m◻[39m [2mgroup1value0[22m
+└ [36m◻[39m [2mgroup1value1[22m
 
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "  [2m[22m[2m◻[22m [2mgroup1[22m
-  [2m│ [22m[36m◻[39m group1value0
-  [2m└ [22m[2m◻[22m [2mgroup1value1[22m
+  "[2m[22m[2m◻[22m [2mgroup1[22m
+[2m│ [22m[36m◻[39m group1value0
+[2m└ [22m[2m◻[22m [2mgroup1value1[22m
 
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "  [2m│ [22m[32m◼[39m group1value0",
+  "[2m│ [22m[32m◼[39m group1value0",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=5>",
   "<erase.down>",
@@ -854,23 +1161,23 @@ exports[`groupMultiselect (isCI = true) > global withGuide: false removes guide 
 [
   "<cursor.hide>",
   "[36m◆[39m  foo
-  [2m[22m[36m◻[39m group1
-  │ [36m◻[39m [2mgroup1value0[22m
-  └ [36m◻[39m [2mgroup1value1[22m
+[2m[22m[36m◻[39m group1
+│ [36m◻[39m [2mgroup1value0[22m
+└ [36m◻[39m [2mgroup1value1[22m
 
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "  [2m[22m[2m◻[22m [2mgroup1[22m
-  [2m│ [22m[36m◻[39m group1value0
-  [2m└ [22m[2m◻[22m [2mgroup1value1[22m
+  "[2m[22m[2m◻[22m [2mgroup1[22m
+[2m│ [22m[36m◻[39m group1value0
+[2m└ [22m[2m◻[22m [2mgroup1value1[22m
 
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "  [2m│ [22m[32m◼[39m group1value0",
+  "[2m│ [22m[32m◼[39m group1value0",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=5>",
   "<erase.down>",
@@ -927,12 +1234,12 @@ exports[`groupMultiselect (isCI = true) > groupSpacing > renders spaced groups 1
   "<cursor.hide>",
   "[90m│[39m
 [36m◆[39m  foo
-[36m│[39m
-[36m│[39m
+[36m│[39m  
+[36m│[39m  
 [36m│[39m  [2m[22m[36m◻[39m group1
 [36m│[39m  └ [36m◻[39m [2mgroup1value0[22m
-[36m│[39m
-[36m│[39m
+[36m│[39m  
+[36m│[39m  
 [36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
 [36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
 [36m└[39m
@@ -942,8 +1249,8 @@ exports[`groupMultiselect (isCI = true) > groupSpacing > renders spaced groups 1
   "<erase.down>",
   "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
 [36m│[39m  [2m└ [22m[36m◻[39m group1value0
-[36m│[39m
-[36m│[39m
+[36m│[39m  
+[36m│[39m  
 [36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
 [36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
 [36m└[39m
@@ -953,8 +1260,8 @@ exports[`groupMultiselect (isCI = true) > groupSpacing > renders spaced groups 1
   "<erase.down>",
   "[36m│[39m  [2m[22m[32m◼[39m [2mgroup1[22m
 [36m│[39m  [2m└ [22m[32m◼[39m group1value0
-[36m│[39m
-[36m│[39m
+[36m│[39m  
+[36m│[39m  
 [36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
 [36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
 [36m└[39m
@@ -985,6 +1292,96 @@ exports[`groupMultiselect (isCI = true) > initial values can be set 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mgroup1value1[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`groupMultiselect (isCI = true) > maxItems renders a sliding window 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value2[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value0
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value0[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value1
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value2
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m...[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value3
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value4
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value5[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group1value5
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=5>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2m└ [22m[32m◼[39m group1value5",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup1value5[22m",
   "
 ",
   "<cursor.show>",
@@ -1138,6 +1535,223 @@ exports[`groupMultiselect (isCI = true) > selectableGroups = false > selecting a
 ]
 `;
 
+exports[`groupMultiselect (isCI = true) > sliding window loops downwards 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value2[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value0
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value0[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value1
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value2
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m...[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value3
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value4
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value5[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group1value5
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value4[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value5[22m
+[36m│[39m  [2m[22m[36m◻[39m group2
+[36m│[39m  │ [36m◻[39m [2mgroup2value0[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value5[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value0
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value1[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value0[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value1
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value2[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value0[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value2
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value2[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value3
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value4[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value5[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=5>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value3[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group2value4
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value5[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=6>",
+  "<erase.down>",
+  "[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value4[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group2value5
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value2[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value0
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2m│ [22m[32m◼[39m group1value0",
+  "<cursor.down count=6>",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup1value0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`groupMultiselect (isCI = true) > sliding window loops upwards 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value2[22m
+[36m│[39m  │ [36m◻[39m [2mgroup1value3[22m
+[36m│[39m  [2m...[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m...[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value1[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value2[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value3[22m
+[36m│[39m  [2m│ [22m[2m◻[22m [2mgroup2value4[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group2value5
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=7>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2m└ [22m[32m◼[39m group2value5",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup2value5[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`groupMultiselect (isCI = true) > values can be non-primitive 1`] = `
 [
   "<cursor.hide>",
@@ -1176,23 +1790,23 @@ exports[`groupMultiselect (isCI = true) > withGuide: false removes guide 1`] = `
 [
   "<cursor.hide>",
   "[36m◆[39m  foo
-  [2m[22m[36m◻[39m group1
-  │ [36m◻[39m [2mgroup1value0[22m
-  └ [36m◻[39m [2mgroup1value1[22m
+[2m[22m[36m◻[39m group1
+│ [36m◻[39m [2mgroup1value0[22m
+└ [36m◻[39m [2mgroup1value1[22m
 
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "  [2m[22m[2m◻[22m [2mgroup1[22m
-  [2m│ [22m[36m◻[39m group1value0
-  [2m└ [22m[2m◻[22m [2mgroup1value1[22m
+  "[2m[22m[2m◻[22m [2mgroup1[22m
+[2m│ [22m[36m◻[39m group1value0
+[2m└ [22m[2m◻[22m [2mgroup1value1[22m
 
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "  [2m│ [22m[32m◼[39m group1value0",
+  "[2m│ [22m[32m◼[39m group1value0",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=5>",
   "<erase.down>",

--- a/packages/prompts/test/group-multi-select.test.ts
+++ b/packages/prompts/test/group-multi-select.test.ts
@@ -306,6 +306,76 @@ describe.each(['true', 'false'])('groupMultiselect (isCI = %s)', (isCI) => {
 		expect(output.buffer).toMatchSnapshot();
 	});
 
+	test('maxItems renders a sliding window', async () => {
+		const result = prompts.groupMultiselect({
+			message: 'foo',
+			input,
+			output,
+			options: {
+				group1: [...Array(6).keys()].map((k) => ({ value: `group1value${k}` })),
+				group2: [...Array(6).keys()].map((k) => ({ value: `group2value${k}` })),
+			},
+			maxItems: 6,
+		});
+
+		for (let i = 0; i < 6; i++) {
+			input.emit('keypress', '', { name: 'down' });
+		}
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toEqual(['group1value5']);
+		expect(output.buffer).toMatchSnapshot();
+	});
+
+	test('sliding window loops upwards', async () => {
+		const result = prompts.groupMultiselect({
+			message: 'foo',
+			input,
+			output,
+			options: {
+				group1: [...Array(6).keys()].map((k) => ({ value: `group1value${k}` })),
+				group2: [...Array(6).keys()].map((k) => ({ value: `group2value${k}` })),
+			},
+			maxItems: 6,
+		});
+
+		input.emit('keypress', '', { name: 'up' });
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toEqual(['group2value5']);
+		expect(output.buffer).toMatchSnapshot();
+	});
+
+	test('sliding window loops downwards', async () => {
+		const result = prompts.groupMultiselect({
+			message: 'foo',
+			input,
+			output,
+			options: {
+				group1: [...Array(6).keys()].map((k) => ({ value: `group1value${k}` })),
+				group2: [...Array(6).keys()].map((k) => ({ value: `group2value${k}` })),
+			},
+			maxItems: 6,
+		});
+
+		for (let i = 0; i < 15; i++) {
+			input.emit('keypress', '', { name: 'down' });
+		}
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toEqual(['group1value0']);
+		expect(output.buffer).toMatchSnapshot();
+	});
+
 	describe('groupSpacing', () => {
 		test('renders spaced groups', async () => {
 			const result = prompts.groupMultiselect({


### PR DESCRIPTION
## What does this PR do?

If `groupMultiselect` have many items, it interferes with the rendering instead of scrolling itself. This PR implements the scrolling behaviour similar to `multiselect` using `limitOptions`.

Also, due to refactoring for `limitOptions`, if `withGuide: false`, the multiselect will no longer have an indent, which matches the styling of `multiselect` and other prompts.

Closes #526

Demo:

https://github.com/user-attachments/assets/80de09fa-8282-420c-ba04-1a7685945b9a

### Additional notes

1. Much of the code and tests are referenced from `multiselect`
2. `limitOptions` does not seem to handle new lines within options well, which could happen when `groupPadding > 0` is set (which prepends new lines before group options). It assumes every option takes up one line when calculating the truncation. I did not fix this in the PR as I feel it's a separate issue.
3. I thought about making the group option sticky, but I feel the scrolling could be a bit unpredictable and complex to work out.

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
