### PR TITLE
chore(ci): harden GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -14,8 +16,7 @@ concurrency:
 jobs:
   scripts:
     if: github.repository_owner == 'bombshell-dev'
-    uses: bombshell-dev/automation/.github/workflows/run.yml@main
-    secrets: inherit
+    uses: bombshell-dev/automation/.github/workflows/run.yml@3a8b4a38fe464b0b51d14962ae416a169517fba9  # main as of 2026-05-12
     with:
       commands: >
         [

--- a/.github/workflows/detect-agent.yml
+++ b/.github/workflows/detect-agent.yml
@@ -5,15 +5,19 @@ on:
     types: [opened]
   workflow_dispatch: {}
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   detect:
-    if: github.event_name != 'workflow_dispatch'
-    uses: bombshell-dev/automation/.github/workflows/detect-agent.yml@main
+    if: github.repository_owner == 'bombshell-dev' && github.event_name != 'workflow_dispatch'
+    uses: bombshell-dev/automation/.github/workflows/detect-agent.yml@3a8b4a38fe464b0b51d14962ae416a169517fba9  # main as of 2026-05-12
+    permissions:
+      issues: write
+      pull-requests: write
 
   backfill:
-    if: github.event_name == 'workflow_dispatch'
-    uses: bombshell-dev/automation/.github/workflows/detect-agent-backfill.yml@main
+    if: github.repository_owner == 'bombshell-dev' && github.event_name == 'workflow_dispatch'
+    uses: bombshell-dev/automation/.github/workflows/detect-agent-backfill.yml@3a8b4a38fe464b0b51d14962ae416a169517fba9  # main as of 2026-05-12
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,11 +6,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   format:
     if: github.repository_owner == 'bombshell-dev'
-    uses: bombshell-dev/automation/.github/workflows/format.yml@main
+    uses: bombshell-dev/automation/.github/workflows/format.yml@3a8b4a38fe464b0b51d14962ae416a169517fba9  # main as of 2026-05-12
     permissions:
       contents: write
       pull-requests: write
-    secrets: inherit
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -4,13 +4,19 @@ on:
   issues:
     types: [opened, edited, labeled, reopened]
 
+permissions: {}
+
 jobs:
   backlog:
     if: github.event.action == 'edited' || github.event.action == 'labeled'
-    uses: bombshell-dev/automation/.github/workflows/move-issue-to-backlog.yml@main
-    secrets: inherit
+    uses: bombshell-dev/automation/.github/workflows/move-issue-to-backlog.yml@3a8b4a38fe464b0b51d14962ae416a169517fba9  # main as of 2026-05-12
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}
 
   project:
     if: github.event.action == 'opened' || github.event.action == 'reopened'
-    uses: bombshell-dev/automation/.github/workflows/add-issue-to-project.yml@main
-    secrets: inherit
+    uses: bombshell-dev/automation/.github/workflows/add-issue-to-project.yml@3a8b4a38fe464b0b51d14962ae416a169517fba9  # main as of 2026-05-12
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,14 +5,16 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+permissions: {}
 
 jobs:
   preview:
     if: github.repository_owner == 'bombshell-dev'
-    uses: bombshell-dev/automation/.github/workflows/preview.yml@main
-    permissions: 
+    uses: bombshell-dev/automation/.github/workflows/preview.yml@3a8b4a38fe464b0b51d14962ae416a169517fba9  # main as of 2026-05-12
+    permissions:
       contents: write
       pull-requests: write
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,17 @@ on:
     branches: [main, v0]
   workflow_dispatch:
 
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-  packages: write
+permissions: {}
 
 jobs:
   publish:
     if: github.repository_owner == 'bombshell-dev'
-    uses: bombshell-dev/automation/.github/workflows/publish.yml@main
-    secrets: inherit
+    uses: bombshell-dev/automation/.github/workflows/publish.yml@3a8b4a38fe464b0b51d14962ae416a169517fba9  # main as of 2026-05-12
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      packages: write
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -1,18 +1,17 @@
-name: Require “Allow Edits”
+name: Require "Allow Edits"
 
 on: [pull_request_target]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   _:
     permissions:
       pull-requests: read
 
-    name: "Require “Allow Edits”"
+    name: "Require \"Allow Edits\""
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ljharb/require-allow-edits@v2
+      - uses: ljharb/require-allow-edits@be4a9d13001dfa5bfc10af68313bad753d7bdc6a  # v2


### PR DESCRIPTION
## What does this PR do?

Hardens our workflows in response to GHSA-g7cv-rxg3-hmpx. Workflows are also being hardened upstream in [`automations#22`](https://github.com/bombshell-dev/automations/pull/22).

- Replaces `secrets: inherit` with explicit secret pass-through on all workflows (or drops entirely where no secrets are needed)
- Pins all `bombshell-dev/automation` reusable workflow refs to SHA (`3a8b4a38...`, main as of 2026-05-12)
- Pins `ljharb/require-allow-edits` to SHA (`be4a9d13...`, v2)
- Adds `permissions: {}` default-deny at workflow level on all 7 workflow files
- Adds owner guard to `detect-agent.yml` jobs
- Narrows `preview.yml` PR trigger types to `[opened, synchronize, reopened]`
- Adds `.github/dependabot.yml` for automated SHA bumps on GitHub Actions

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code

Claude helped 🙃 
