### PR TITLE
feat(prompts): add onCancel callback option to all prompts

### DIFF
--- a/.changeset/on-cancel-callback.md
+++ b/.changeset/on-cancel-callback.md
@@ -1,0 +1,24 @@
+---
+"@clack/prompts": patch
+---
+
+Add `onCancel` callback option to all prompts
+
+All prompt functions now accept an optional `onCancel` callback that is
+invoked when the user cancels (Ctrl+C or Escape). When the callback's
+return type is `never` (e.g. it calls `process.exit` or throws), the
+prompt's return type narrows to exclude the cancel symbol:
+
+```ts
+const result = await confirm({
+  message: 'Continue?',
+  onCancel: () => {
+    cancel('Operation cancelled.');
+    process.exit(0);
+  },
+});
+// result is `boolean` — no `isCancel` guard needed
+```
+
+For callbacks that return `void`, the return type remains `T | symbol` as
+before. Also exports `handleCancel` utility for custom prompt implementations.

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -44,6 +44,33 @@ if (isCancel(value)) {
 }
 ```
 
+You can also provide an `onCancel` callback on any prompt to handle cancellation inline.
+When the callback calls `process.exit` or throws, the return type narrows to exclude the cancel symbol:
+
+```js
+import { cancel, text } from '@clack/prompts';
+
+const value = await text({
+  message: 'What is the meaning of life?',
+  onCancel: () => {
+    cancel('Operation cancelled.');
+    process.exit(0);
+  },
+});
+// value is `string` — no `isCancel` guard needed
+```
+
+Note: type narrowing only works when options are passed inline. If you extract options into a typed variable, the callback type widens to `() => void` and narrowing is lost:
+
+```js
+// Narrowing does NOT work here — result is `string | symbol`
+const opts: TextOptions = {
+  message: 'What is the meaning of life?',
+  onCancel: () => { process.exit(0); },
+};
+const value = await text(opts);
+```
+
 ## Components
 
 ### Text

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -3,6 +3,7 @@ import type { Validate } from '@clack/core';
 import { AutocompletePrompt, settings } from '@clack/core';
 import {
 	type CommonOptions,
+	handleCancel,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_INACTIVE,
@@ -120,7 +121,11 @@ export interface AutocompleteOptions<Value> extends AutocompleteSharedOptions<Va
  * });
  * ```
  */
-export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
+export function autocomplete<Value>(
+	opts: AutocompleteOptions<Value> & { onCancel: () => never }
+): Promise<Value>;
+export function autocomplete<Value>(opts: AutocompleteOptions<Value>): Promise<Value | symbol>;
+export function autocomplete<Value>(opts: AutocompleteOptions<Value>): Promise<Value | symbol> {
 	const prompt = new AutocompletePrompt({
 		options: opts.options,
 		initialValue: opts.initialValue ? [opts.initialValue] : undefined,
@@ -260,8 +265,8 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 	});
 
 	// Return the result or cancel symbol
-	return prompt.prompt() as Promise<Value | symbol>;
-};
+	return handleCancel(prompt.prompt() as Promise<Value | symbol>, opts.onCancel);
+}
 
 /**
  * Options for the {@link autocompleteMultiselect} prompt
@@ -303,7 +308,15 @@ export interface AutocompleteMultiSelectOptions<Value> extends AutocompleteShare
  * });
  * ```
  */
-export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOptions<Value>) => {
+export function autocompleteMultiselect<Value>(
+	opts: AutocompleteMultiSelectOptions<Value> & { onCancel: () => never }
+): Promise<Value[]>;
+export function autocompleteMultiselect<Value>(
+	opts: AutocompleteMultiSelectOptions<Value>
+): Promise<Value[] | symbol>;
+export function autocompleteMultiselect<Value>(
+	opts: AutocompleteMultiSelectOptions<Value>
+): Promise<Value[] | symbol> {
 	const formatOption = (
 		option: Option<Value>,
 		active: boolean,
@@ -444,5 +457,5 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 	});
 
 	// Return the result or cancel symbol
-	return prompt.prompt() as Promise<Value[] | symbol>;
-};
+	return handleCancel(prompt.prompt() as Promise<Value[] | symbol>, opts.onCancel);
+}

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -1,6 +1,7 @@
 import type { Readable, Writable } from 'node:stream';
 import { styleText } from 'node:util';
 import type { State } from '@clack/core';
+import { isCancel } from '@clack/core';
 import isUnicodeSupported from 'is-unicode-supported';
 
 export const unicode = isUnicodeSupported();
@@ -72,4 +73,31 @@ export interface CommonOptions {
 	output?: Writable;
 	signal?: AbortSignal;
 	withGuide?: boolean;
+	/**
+	 * Called when the user cancels the prompt (Ctrl+C or Escape).
+	 * If the callback returns `never` (e.g. calls `process.exit` or throws),
+	 * the prompt's return type narrows to exclude the cancel symbol.
+	 */
+	onCancel?: () => void;
+}
+
+/**
+ * Wraps a prompt promise with an onCancel callback.
+ * If the result is a cancel symbol, the callback is invoked before the symbol
+ * is returned. If the callback throws, the promise rejects with that error
+ * and the symbol is never returned.
+ */
+export function handleCancel<T>(
+	promise: Promise<T | symbol>,
+	onCancel?: () => void
+): Promise<T | symbol> {
+	if (!onCancel) return promise;
+	return promise.then((result) => {
+		if (isCancel(result)) {
+			// Callback fires before the symbol is returned.
+			// If onCancel throws, the symbol is never returned.
+			onCancel();
+		}
+		return result;
+	});
 }

--- a/packages/prompts/src/confirm.ts
+++ b/packages/prompts/src/confirm.ts
@@ -2,6 +2,7 @@ import { styleText } from 'node:util';
 import { ConfirmPrompt, settings, wrapTextWithPrefix } from '@clack/core';
 import {
 	type CommonOptions,
+	handleCancel,
 	S_BAR,
 	S_BAR_END,
 	S_RADIO_ACTIVE,
@@ -58,54 +59,59 @@ export interface ConfirmOptions extends CommonOptions {
  * });
  * ```
  */
-export const confirm = (opts: ConfirmOptions) => {
+export function confirm(opts: ConfirmOptions & { onCancel: () => never }): Promise<boolean>;
+export function confirm(opts: ConfirmOptions): Promise<boolean | symbol>;
+export function confirm(opts: ConfirmOptions): Promise<boolean | symbol> {
 	const active = opts.active ?? 'Yes';
 	const inactive = opts.inactive ?? 'No';
-	return new ConfirmPrompt({
-		active,
-		inactive,
-		signal: opts.signal,
-		input: opts.input,
-		output: opts.output,
-		initialValue: opts.initialValue ?? true,
-		render() {
-			const hasGuide = opts.withGuide ?? settings.withGuide;
-			const titlePrefix = `${symbol(this.state)}  `;
-			const titlePrefixBar = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-			const messageLines = wrapTextWithPrefix(
-				opts.output,
-				opts.message,
-				titlePrefixBar,
-				titlePrefix
-			);
-			const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${messageLines}\n`;
-			const value = this.value ? active : inactive;
+	return handleCancel(
+		new ConfirmPrompt({
+			active,
+			inactive,
+			signal: opts.signal,
+			input: opts.input,
+			output: opts.output,
+			initialValue: opts.initialValue ?? true,
+			render() {
+				const hasGuide = opts.withGuide ?? settings.withGuide;
+				const titlePrefix = `${symbol(this.state)}  `;
+				const titlePrefixBar = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+				const messageLines = wrapTextWithPrefix(
+					opts.output,
+					opts.message,
+					titlePrefixBar,
+					titlePrefix
+				);
+				const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${messageLines}\n`;
+				const value = this.value ? active : inactive;
 
-			switch (this.state) {
-				case 'submit': {
-					const submitPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-					return `${title}${submitPrefix}${styleText('dim', value)}`;
+				switch (this.state) {
+					case 'submit': {
+						const submitPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+						return `${title}${submitPrefix}${styleText('dim', value)}`;
+					}
+					case 'cancel': {
+						const cancelPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+						return `${title}${cancelPrefix}${styleText(['strikethrough', 'dim'], value)}${
+							hasGuide ? `\n${styleText('gray', S_BAR)}` : ''
+						}`;
+					}
+					default: {
+						const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
+						return `${title}${defaultPrefix}${
+							this.value
+								? `${styleText('green', S_RADIO_ACTIVE)} ${active}`
+								: `${styleText('dim', S_RADIO_INACTIVE)} ${styleText('dim', active)}`
+						}${opts.vertical ? (hasGuide ? `\n${styleText('cyan', S_BAR)}  ` : '\n') : ` ${styleText('dim', '/')} `}${
+							!this.value
+								? `${styleText('green', S_RADIO_ACTIVE)} ${inactive}`
+								: `${styleText('dim', S_RADIO_INACTIVE)} ${styleText('dim', inactive)}`
+						}\n${defaultPrefixEnd}\n`;
+					}
 				}
-				case 'cancel': {
-					const cancelPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-					return `${title}${cancelPrefix}${styleText(['strikethrough', 'dim'], value)}${
-						hasGuide ? `\n${styleText('gray', S_BAR)}` : ''
-					}`;
-				}
-				default: {
-					const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
-					return `${title}${defaultPrefix}${
-						this.value
-							? `${styleText('green', S_RADIO_ACTIVE)} ${active}`
-							: `${styleText('dim', S_RADIO_INACTIVE)} ${styleText('dim', active)}`
-					}${opts.vertical ? (hasGuide ? `\n${styleText('cyan', S_BAR)}  ` : '\n') : ` ${styleText('dim', '/')} `}${
-						!this.value
-							? `${styleText('green', S_RADIO_ACTIVE)} ${inactive}`
-							: `${styleText('dim', S_RADIO_INACTIVE)} ${styleText('dim', inactive)}`
-					}\n${defaultPrefixEnd}\n`;
-				}
-			}
-		},
-	}).prompt() as Promise<boolean | symbol>;
-};
+			},
+		}).prompt() as Promise<boolean | symbol>,
+		opts.onCancel
+	);
+}

--- a/packages/prompts/src/date.ts
+++ b/packages/prompts/src/date.ts
@@ -1,7 +1,7 @@
 import { styleText } from 'node:util';
 import type { DateFormat, State, Validate } from '@clack/core';
 import { DatePrompt, runValidation, settings } from '@clack/core';
-import { type CommonOptions, S_BAR, S_BAR_END, symbol } from './common.js';
+import { type CommonOptions, handleCancel, S_BAR, S_BAR_END, symbol } from './common.js';
 
 export type { DateFormat };
 
@@ -22,66 +22,71 @@ export interface DateOptions extends CommonOptions {
 	validate?: Validate<Date>;
 }
 
-export const date = (opts: DateOptions) => {
+export function date(opts: DateOptions & { onCancel: () => never }): Promise<Date>;
+export function date(opts: DateOptions): Promise<Date | symbol>;
+export function date(opts: DateOptions): Promise<Date | symbol> {
 	const validate = opts.validate;
-	return new DatePrompt({
-		...opts,
-		validate(value: Date | undefined) {
-			if (value === undefined) {
-				if (opts.defaultValue !== undefined) return undefined;
+	return handleCancel(
+		new DatePrompt({
+			...opts,
+			validate(value: Date | undefined) {
+				if (value === undefined) {
+					if (opts.defaultValue !== undefined) return undefined;
+					if (validate) return runValidation(validate, value);
+					return settings.date.messages.required;
+				}
+				const iso = (d: Date) => d.toISOString().slice(0, 10);
+				if (opts.minDate && iso(value) < iso(opts.minDate)) {
+					return settings.date.messages.afterMin(opts.minDate);
+				}
+				if (opts.maxDate && iso(value) > iso(opts.maxDate)) {
+					return settings.date.messages.beforeMax(opts.maxDate);
+				}
 				if (validate) return runValidation(validate, value);
-				return settings.date.messages.required;
-			}
-			const iso = (d: Date) => d.toISOString().slice(0, 10);
-			if (opts.minDate && iso(value) < iso(opts.minDate)) {
-				return settings.date.messages.afterMin(opts.minDate);
-			}
-			if (opts.maxDate && iso(value) > iso(opts.maxDate)) {
-				return settings.date.messages.beforeMax(opts.maxDate);
-			}
-			if (validate) return runValidation(validate, value);
-			return undefined;
-		},
-		render() {
-			const hasGuide = (opts?.withGuide ?? settings.withGuide) !== false;
-			const titlePrefix = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  `;
-			const title = `${titlePrefix}${opts.message}\n`;
+				return undefined;
+			},
+			render() {
+				const hasGuide = (opts?.withGuide ?? settings.withGuide) !== false;
+				const titlePrefix = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  `;
+				const title = `${titlePrefix}${opts.message}\n`;
 
-			const state = this.state !== 'initial' ? this.state : 'active';
+				const state = this.state !== 'initial' ? this.state : 'active';
 
-			const userInput = renderDate(this, state);
-			const value = this.value instanceof Date ? this.formattedValue : '';
+				const userInput = renderDate(this, state);
+				const value = this.value instanceof Date ? this.formattedValue : '';
 
-			switch (this.state) {
-				case 'error': {
-					const errorText = this.error ? `  ${styleText('yellow', this.error)}` : '';
-					const bar = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
-					const barEnd = hasGuide ? styleText('yellow', S_BAR_END) : '';
-					return `${title.trim()}\n${bar}${userInput}\n${barEnd}${errorText}\n`;
+				switch (this.state) {
+					case 'error': {
+						const errorText = this.error ? `  ${styleText('yellow', this.error)}` : '';
+						const bar = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
+						const barEnd = hasGuide ? styleText('yellow', S_BAR_END) : '';
+						return `${title.trim()}\n${bar}${userInput}\n${barEnd}${errorText}\n`;
+					}
+					case 'submit': {
+						const valueText = value ? `  ${styleText('dim', value)}` : '';
+						const bar = hasGuide ? styleText('gray', S_BAR) : '';
+						return `${title}${bar}${valueText}`;
+					}
+					case 'cancel': {
+						const valueText = value ? `  ${styleText(['strikethrough', 'dim'], value)}` : '';
+						const bar = hasGuide ? styleText('gray', S_BAR) : '';
+						return `${title}${bar}${valueText}${value.trim() ? `\n${bar}` : ''}`;
+					}
+					default: {
+						const bar = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						const barEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
+						const inlineBar = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						const inlineError = this.inlineError
+							? `\n${inlineBar}${styleText('yellow', this.inlineError)}`
+							: '';
+						return `${title}${bar}${userInput}${inlineError}\n${barEnd}\n`;
+					}
 				}
-				case 'submit': {
-					const valueText = value ? `  ${styleText('dim', value)}` : '';
-					const bar = hasGuide ? styleText('gray', S_BAR) : '';
-					return `${title}${bar}${valueText}`;
-				}
-				case 'cancel': {
-					const valueText = value ? `  ${styleText(['strikethrough', 'dim'], value)}` : '';
-					const bar = hasGuide ? styleText('gray', S_BAR) : '';
-					return `${title}${bar}${valueText}${value.trim() ? `\n${bar}` : ''}`;
-				}
-				default: {
-					const bar = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const barEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
-					const inlineBar = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const inlineError = this.inlineError
-						? `\n${inlineBar}${styleText('yellow', this.inlineError)}`
-						: '';
-					return `${title}${bar}${userInput}${inlineError}\n${barEnd}\n`;
-				}
-			}
-		},
-	}).prompt() as Promise<Date | symbol>;
-};
+			},
+		}).prompt() as Promise<Date | symbol>,
+		opts.onCancel
+	);
+}
 
 function renderDate(prompt: Omit<InstanceType<typeof DatePrompt>, 'prompt'>, state: State): string {
 	const parts = prompt.segmentValues;

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -2,6 +2,7 @@ import { styleText } from 'node:util';
 import { GroupMultiSelectPrompt, settings, wrapTextWithPrefix } from '@clack/core';
 import {
 	type CommonOptions,
+	handleCancel,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_ACTIVE,
@@ -87,7 +88,15 @@ export interface GroupMultiSelectOptions<Value> extends CommonOptions {
  *
  * @param opts The options for the group multiselect prompt
  */
-export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) => {
+export function groupMultiselect<Value>(
+	opts: GroupMultiSelectOptions<Value> & { onCancel: () => never }
+): Promise<Value[]>;
+export function groupMultiselect<Value>(
+	opts: GroupMultiSelectOptions<Value>
+): Promise<Value[] | symbol>;
+export function groupMultiselect<Value>(
+	opts: GroupMultiSelectOptions<Value>
+): Promise<Value[] | symbol> {
 	const { selectableGroups = true, groupSpacing = 0 } = opts;
 	const opt = (
 		option: Option<Value> & { group: string | boolean },
@@ -190,118 +199,123 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 	};
 	const required = opts.required ?? true;
 
-	return new GroupMultiSelectPrompt({
-		options: opts.options,
-		signal: opts.signal,
-		input: opts.input,
-		output: opts.output,
-		initialValues: opts.initialValues,
-		required,
-		cursorAt: opts.cursorAt,
-		selectableGroups,
-		validate(selected: Value[] | undefined) {
-			if (required && (selected === undefined || selected.length === 0))
-				return `Please select at least one option.\n${styleText(
-					'reset',
-					styleText(
-						'dim',
-						`Press ${styleText(['gray', 'bgWhite', 'inverse'], ' space ')} to select, ${styleText(
-							'gray',
-							styleText(['bgWhite', 'inverse'], ' enter ')
-						)} to submit`
-					)
-				)}`;
-		},
-		render() {
-			const hasGuide = opts.withGuide ?? settings.withGuide;
-			const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
-			const value = this.value ?? [];
-
-			const styleOption = (
-				option: Option<Value> & { group: string | boolean },
-				active: boolean
-			) => {
-				const options = this.options;
-				const selected =
-					value.includes(option.value) ||
-					(option.group === true && this.isGroupSelected(`${option.value}`));
-				const groupActive =
-					!active &&
-					typeof option.group === 'string' &&
-					this.options[this.cursor].value === option.group;
-				if (groupActive) {
-					return opt(option, selected ? 'group-active-selected' : 'group-active', options);
-				}
-				if (active && selected) {
-					return opt(option, 'active-selected', options);
-				}
-				if (selected) {
-					return opt(option, 'selected', options);
-				}
-				return opt(option, active ? 'active' : 'inactive', options);
-			};
-
-			switch (this.state) {
-				case 'submit': {
-					const selectedOptions = this.options
-						.filter(({ value: optionValue }) => value.includes(optionValue))
-						.map((option) => opt(option, 'submitted'));
-					const optionsText =
-						selectedOptions.length === 0 ? '' : `  ${selectedOptions.join(styleText('dim', ', '))}`;
-					return `${title}${hasGuide ? styleText('gray', S_BAR) : ''}${optionsText}`;
-				}
-				case 'cancel': {
-					const label = this.options
-						.filter(({ value: optionValue }) => value.includes(optionValue))
-						.map((option) => opt(option, 'cancelled'))
-						.join(styleText('dim', ', '));
-					return `${title}${hasGuide ? `${styleText('gray', S_BAR)}  ` : ''}${
-						label.trim() ? `${label}${hasGuide ? `\n${styleText('gray', S_BAR)}` : ''}` : ''
-					}`;
-				}
-				case 'error': {
-					const guidePrefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
-					const footer = this.error
-						.split('\n')
-						.map((ln, i) =>
-							i === 0
-								? `${hasGuide ? `${styleText('yellow', S_BAR_END)}  ` : ''}${styleText('yellow', ln)}`
-								: `   ${ln}`
+	return handleCancel(
+		new GroupMultiSelectPrompt({
+			options: opts.options,
+			signal: opts.signal,
+			input: opts.input,
+			output: opts.output,
+			initialValues: opts.initialValues,
+			required,
+			cursorAt: opts.cursorAt,
+			selectableGroups,
+			validate(selected: Value[] | undefined) {
+				if (required && (selected === undefined || selected.length === 0))
+					return `Please select at least one option.\n${styleText(
+						'reset',
+						styleText(
+							'dim',
+							`Press ${styleText(['gray', 'bgWhite', 'inverse'], ' space ')} to select, ${styleText(
+								'gray',
+								styleText(['bgWhite', 'inverse'], ' enter ')
+							)} to submit`
 						)
-						.join('\n');
-					// Calculate rowPadding: title lines + footer lines (error message + trailing newline)
-					const titleLineCount = title.split('\n').length;
-					const footerLineCount = footer.split('\n').length + 1; // footer + trailing newline
-					const optionsText = limitOptions({
-						output: opts.output,
-						options: this.options,
-						cursor: this.cursor,
-						maxItems: opts.maxItems,
-						columnPadding: guidePrefix.length,
-						rowPadding: titleLineCount + footerLineCount,
-						style: styleOption,
-					}).join(`\n${guidePrefix}`);
-					return `${title}${guidePrefix}${optionsText}\n${footer}\n`;
+					)}`;
+			},
+			render() {
+				const hasGuide = opts.withGuide ?? settings.withGuide;
+				const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
+				const value = this.value ?? [];
+
+				const styleOption = (
+					option: Option<Value> & { group: string | boolean },
+					active: boolean
+				) => {
+					const options = this.options;
+					const selected =
+						value.includes(option.value) ||
+						(option.group === true && this.isGroupSelected(`${option.value}`));
+					const groupActive =
+						!active &&
+						typeof option.group === 'string' &&
+						this.options[this.cursor].value === option.group;
+					if (groupActive) {
+						return opt(option, selected ? 'group-active-selected' : 'group-active', options);
+					}
+					if (active && selected) {
+						return opt(option, 'active-selected', options);
+					}
+					if (selected) {
+						return opt(option, 'selected', options);
+					}
+					return opt(option, active ? 'active' : 'inactive', options);
+				};
+
+				switch (this.state) {
+					case 'submit': {
+						const selectedOptions = this.options
+							.filter(({ value: optionValue }) => value.includes(optionValue))
+							.map((option) => opt(option, 'submitted'));
+						const optionsText =
+							selectedOptions.length === 0
+								? ''
+								: `  ${selectedOptions.join(styleText('dim', ', '))}`;
+						return `${title}${hasGuide ? styleText('gray', S_BAR) : ''}${optionsText}`;
+					}
+					case 'cancel': {
+						const label = this.options
+							.filter(({ value: optionValue }) => value.includes(optionValue))
+							.map((option) => opt(option, 'cancelled'))
+							.join(styleText('dim', ', '));
+						return `${title}${hasGuide ? `${styleText('gray', S_BAR)}  ` : ''}${
+							label.trim() ? `${label}${hasGuide ? `\n${styleText('gray', S_BAR)}` : ''}` : ''
+						}`;
+					}
+					case 'error': {
+						const guidePrefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
+						const footer = this.error
+							.split('\n')
+							.map((ln, i) =>
+								i === 0
+									? `${hasGuide ? `${styleText('yellow', S_BAR_END)}  ` : ''}${styleText('yellow', ln)}`
+									: `   ${ln}`
+							)
+							.join('\n');
+						// Calculate rowPadding: title lines + footer lines (error message + trailing newline)
+						const titleLineCount = title.split('\n').length;
+						const footerLineCount = footer.split('\n').length + 1; // footer + trailing newline
+						const optionsText = limitOptions({
+							output: opts.output,
+							options: this.options,
+							cursor: this.cursor,
+							maxItems: opts.maxItems,
+							columnPadding: guidePrefix.length,
+							rowPadding: titleLineCount + footerLineCount,
+							style: styleOption,
+						}).join(`\n${guidePrefix}`);
+						return `${title}${guidePrefix}${optionsText}\n${footer}\n`;
+					}
+					default: {
+						const guidePrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						// Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
+						const titleLineCount = title.split('\n').length;
+						const footerLineCount = (hasGuide ? 1 : 0) + 1; // guide line + trailing newline
+						const optionsText = limitOptions({
+							output: opts.output,
+							options: this.options,
+							cursor: this.cursor,
+							maxItems: opts.maxItems,
+							columnPadding: guidePrefix.length,
+							rowPadding: titleLineCount + footerLineCount,
+							style: styleOption,
+						}).join(`\n${guidePrefix}`);
+						return `${title}${guidePrefix}${optionsText}\n${
+							hasGuide ? styleText('cyan', S_BAR_END) : ''
+						}\n`;
+					}
 				}
-				default: {
-					const guidePrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					// Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
-					const titleLineCount = title.split('\n').length;
-					const footerLineCount = (hasGuide ? 1 : 0) + 1; // guide line + trailing newline
-					const optionsText = limitOptions({
-						output: opts.output,
-						options: this.options,
-						cursor: this.cursor,
-						maxItems: opts.maxItems,
-						columnPadding: guidePrefix.length,
-						rowPadding: titleLineCount + footerLineCount,
-						style: styleOption,
-					}).join(`\n${guidePrefix}`);
-					return `${title}${guidePrefix}${optionsText}\n${
-						hasGuide ? styleText('cyan', S_BAR_END) : ''
-					}\n`;
-				}
-			}
-		},
-	}).prompt() as Promise<Value[] | symbol>;
-};
+			},
+		}).prompt() as Promise<Value[] | symbol>,
+		opts.onCancel
+	);
+}

--- a/packages/prompts/src/multi-line.ts
+++ b/packages/prompts/src/multi-line.ts
@@ -1,6 +1,6 @@
 import { styleText } from 'node:util';
 import { MultiLinePrompt, settings, wrapTextWithPrefix } from '@clack/core';
-import { S_BAR, S_BAR_END, symbol } from './common.js';
+import { handleCancel, S_BAR, S_BAR_END, symbol } from './common.js';
 import type { TextOptions } from './text.js';
 
 /**
@@ -33,68 +33,73 @@ export interface MultiLineOptions extends TextOptions {
  * });
  * ```
  */
-export const multiline = (opts: MultiLineOptions) => {
-	return new MultiLinePrompt({
-		validate: opts.validate,
-		placeholder: opts.placeholder,
-		defaultValue: opts.defaultValue,
-		initialValue: opts.initialValue,
-		showSubmit: opts.showSubmit,
-		output: opts.output,
-		signal: opts.signal,
-		input: opts.input,
-		render() {
-			const hasGuide = opts?.withGuide ?? settings.withGuide;
-			const titlePrefix = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  `;
-			const title = `${titlePrefix}${opts.message}\n`;
-			const placeholder = opts.placeholder
-				? styleText('inverse', opts.placeholder[0]) + styleText('dim', opts.placeholder.slice(1))
-				: styleText(['inverse', 'hidden'], '_');
-			const userInput = !this.userInput ? placeholder : this.userInputWithCursor;
-			const value = this.value ?? '';
-			const submitButton = opts.showSubmit
-				? `\n  ${styleText(this.focused === 'submit' ? 'cyan' : 'dim', '[ submit ]')}`
-				: '';
-			switch (this.state) {
-				case 'error': {
-					const errorPrefix = `${styleText('yellow', S_BAR)}  `;
-					const lines = hasGuide
-						? wrapTextWithPrefix(opts.output, userInput, errorPrefix, undefined)
-						: userInput;
-					const errorPrefixEnd = styleText('yellow', S_BAR_END);
-					return `${title}${lines}\n${errorPrefixEnd}  ${styleText('yellow', this.error)}${submitButton}\n`;
+export function multiline(opts: MultiLineOptions & { onCancel: () => never }): Promise<string>;
+export function multiline(opts: MultiLineOptions): Promise<string | symbol>;
+export function multiline(opts: MultiLineOptions): Promise<string | symbol> {
+	return handleCancel(
+		new MultiLinePrompt({
+			validate: opts.validate,
+			placeholder: opts.placeholder,
+			defaultValue: opts.defaultValue,
+			initialValue: opts.initialValue,
+			showSubmit: opts.showSubmit,
+			output: opts.output,
+			signal: opts.signal,
+			input: opts.input,
+			render() {
+				const hasGuide = opts?.withGuide ?? settings.withGuide;
+				const titlePrefix = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  `;
+				const title = `${titlePrefix}${opts.message}\n`;
+				const placeholder = opts.placeholder
+					? styleText('inverse', opts.placeholder[0]) + styleText('dim', opts.placeholder.slice(1))
+					: styleText(['inverse', 'hidden'], '_');
+				const userInput = !this.userInput ? placeholder : this.userInputWithCursor;
+				const value = this.value ?? '';
+				const submitButton = opts.showSubmit
+					? `\n  ${styleText(this.focused === 'submit' ? 'cyan' : 'dim', '[ submit ]')}`
+					: '';
+				switch (this.state) {
+					case 'error': {
+						const errorPrefix = `${styleText('yellow', S_BAR)}  `;
+						const lines = hasGuide
+							? wrapTextWithPrefix(opts.output, userInput, errorPrefix, undefined)
+							: userInput;
+						const errorPrefixEnd = styleText('yellow', S_BAR_END);
+						return `${title}${lines}\n${errorPrefixEnd}  ${styleText('yellow', this.error)}${submitButton}\n`;
+					}
+					case 'submit': {
+						const submitPrefix = `${styleText('gray', S_BAR)}  `;
+						const lines = hasGuide
+							? wrapTextWithPrefix(opts.output, value, submitPrefix, undefined, undefined, (str) =>
+									styleText('dim', str)
+								)
+							: value
+								? styleText('dim', value)
+								: '';
+						return `${title}${lines}`;
+					}
+					case 'cancel': {
+						const cancelPrefix = `${styleText('gray', S_BAR)}  `;
+						const lines = hasGuide
+							? wrapTextWithPrefix(opts.output, value, cancelPrefix, undefined, undefined, (str) =>
+									styleText(['strikethrough', 'dim'], str)
+								)
+							: value
+								? styleText(['strikethrough', 'dim'], value)
+								: '';
+						return `${title}${lines}`;
+					}
+					default: {
+						const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
+						const lines = hasGuide
+							? wrapTextWithPrefix(opts.output, userInput, defaultPrefix)
+							: userInput;
+						return `${title}${lines}\n${defaultPrefixEnd}${submitButton}\n`;
+					}
 				}
-				case 'submit': {
-					const submitPrefix = `${styleText('gray', S_BAR)}  `;
-					const lines = hasGuide
-						? wrapTextWithPrefix(opts.output, value, submitPrefix, undefined, undefined, (str) =>
-								styleText('dim', str)
-							)
-						: value
-							? styleText('dim', value)
-							: '';
-					return `${title}${lines}`;
-				}
-				case 'cancel': {
-					const cancelPrefix = `${styleText('gray', S_BAR)}  `;
-					const lines = hasGuide
-						? wrapTextWithPrefix(opts.output, value, cancelPrefix, undefined, undefined, (str) =>
-								styleText(['strikethrough', 'dim'], str)
-							)
-						: value
-							? styleText(['strikethrough', 'dim'], value)
-							: '';
-					return `${title}${lines}`;
-				}
-				default: {
-					const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
-					const lines = hasGuide
-						? wrapTextWithPrefix(opts.output, userInput, defaultPrefix)
-						: userInput;
-					return `${title}${lines}\n${defaultPrefixEnd}${submitButton}\n`;
-				}
-			}
-		},
-	}).prompt() as Promise<string | symbol>;
-};
+			},
+		}).prompt() as Promise<string | symbol>,
+		opts.onCancel
+	);
+}

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -2,6 +2,7 @@ import { styleText } from 'node:util';
 import { MultiSelectPrompt, settings, wrapTextWithPrefix } from '@clack/core';
 import {
 	type CommonOptions,
+	handleCancel,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_ACTIVE,
@@ -28,7 +29,11 @@ const computeLabel = (label: string, format: (text: string) => string) => {
 		.join('\n');
 };
 
-export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
+export function multiselect<Value>(
+	opts: MultiSelectOptions<Value> & { onCancel: () => never }
+): Promise<Value[]>;
+export function multiselect<Value>(opts: MultiSelectOptions<Value>): Promise<Value[] | symbol>;
+export function multiselect<Value>(opts: MultiSelectOptions<Value>): Promise<Value[] | symbol> {
 	const opt = (
 		option: Option<Value>,
 		state:
@@ -71,120 +76,123 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 	};
 	const required = opts.required ?? true;
 
-	return new MultiSelectPrompt({
-		options: opts.options,
-		signal: opts.signal,
-		input: opts.input,
-		output: opts.output,
-		initialValues: opts.initialValues,
-		required,
-		cursorAt: opts.cursorAt,
-		validate(selected: Value[] | undefined) {
-			if (required && (selected === undefined || selected.length === 0))
-				return `Please select at least one option.\n${styleText(
-					'reset',
-					styleText(
-						'dim',
-						`Press ${styleText(['gray', 'bgWhite', 'inverse'], ' space ')} to select, ${styleText(
-							'gray',
-							styleText('bgWhite', styleText('inverse', ' enter '))
-						)} to submit`
-					)
-				)}`;
-		},
-		render() {
-			const hasGuide = opts.withGuide ?? settings.withGuide;
-			const wrappedMessage = wrapTextWithPrefix(
-				opts.output,
-				opts.message,
-				hasGuide ? `${symbolBar(this.state)}  ` : '',
-				`${symbol(this.state)}  `
-			);
-			const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${wrappedMessage}\n`;
-			const value = this.value ?? [];
-
-			const styleOption = (option: Option<Value>, active: boolean) => {
-				if (option.disabled) {
-					return opt(option, 'disabled');
-				}
-				const selected = value.includes(option.value);
-				if (active && selected) {
-					return opt(option, 'active-selected');
-				}
-				if (selected) {
-					return opt(option, 'selected');
-				}
-				return opt(option, active ? 'active' : 'inactive');
-			};
-
-			switch (this.state) {
-				case 'submit': {
-					const submitText =
-						this.options
-							.filter(({ value: optionValue }) => value.includes(optionValue))
-							.map((option) => opt(option, 'submitted'))
-							.join(styleText('dim', ', ')) || styleText('dim', 'none');
-					const wrappedSubmitText = wrapTextWithPrefix(
-						opts.output,
-						submitText,
-						hasGuide ? `${styleText('gray', S_BAR)}  ` : ''
-					);
-					return `${title}${wrappedSubmitText}`;
-				}
-				case 'cancel': {
-					const label = this.options
-						.filter(({ value: optionValue }) => value.includes(optionValue))
-						.map((option) => opt(option, 'cancelled'))
-						.join(styleText('dim', ', '));
-					if (label.trim() === '') {
-						return `${title}${styleText('gray', S_BAR)}`;
-					}
-					const wrappedLabel = wrapTextWithPrefix(
-						opts.output,
-						label,
-						hasGuide ? `${styleText('gray', S_BAR)}  ` : ''
-					);
-					return `${title}${wrappedLabel}${hasGuide ? `\n${styleText('gray', S_BAR)}` : ''}`;
-				}
-				case 'error': {
-					const prefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
-					const footer = this.error
-						.split('\n')
-						.map((ln, i) =>
-							i === 0
-								? `${hasGuide ? `${styleText('yellow', S_BAR_END)}  ` : ''}${styleText('yellow', ln)}`
-								: `   ${ln}`
+	return handleCancel(
+		new MultiSelectPrompt({
+			options: opts.options,
+			signal: opts.signal,
+			input: opts.input,
+			output: opts.output,
+			initialValues: opts.initialValues,
+			required,
+			cursorAt: opts.cursorAt,
+			validate(selected: Value[] | undefined) {
+				if (required && (selected === undefined || selected.length === 0))
+					return `Please select at least one option.\n${styleText(
+						'reset',
+						styleText(
+							'dim',
+							`Press ${styleText(['gray', 'bgWhite', 'inverse'], ' space ')} to select, ${styleText(
+								'gray',
+								styleText('bgWhite', styleText('inverse', ' enter '))
+							)} to submit`
 						)
-						.join('\n');
-					// Calculate rowPadding: title lines + footer lines (error message + trailing newline)
-					const titleLineCount = title.split('\n').length;
-					const footerLineCount = footer.split('\n').length + 1; // footer + trailing newline
-					return `${title}${prefix}${limitOptions({
-						output: opts.output,
-						options: this.options,
-						cursor: this.cursor,
-						maxItems: opts.maxItems,
-						columnPadding: prefix.length,
-						rowPadding: titleLineCount + footerLineCount,
-						style: styleOption,
-					}).join(`\n${prefix}`)}\n${footer}\n`;
+					)}`;
+			},
+			render() {
+				const hasGuide = opts.withGuide ?? settings.withGuide;
+				const wrappedMessage = wrapTextWithPrefix(
+					opts.output,
+					opts.message,
+					hasGuide ? `${symbolBar(this.state)}  ` : '',
+					`${symbol(this.state)}  `
+				);
+				const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${wrappedMessage}\n`;
+				const value = this.value ?? [];
+
+				const styleOption = (option: Option<Value>, active: boolean) => {
+					if (option.disabled) {
+						return opt(option, 'disabled');
+					}
+					const selected = value.includes(option.value);
+					if (active && selected) {
+						return opt(option, 'active-selected');
+					}
+					if (selected) {
+						return opt(option, 'selected');
+					}
+					return opt(option, active ? 'active' : 'inactive');
+				};
+
+				switch (this.state) {
+					case 'submit': {
+						const submitText =
+							this.options
+								.filter(({ value: optionValue }) => value.includes(optionValue))
+								.map((option) => opt(option, 'submitted'))
+								.join(styleText('dim', ', ')) || styleText('dim', 'none');
+						const wrappedSubmitText = wrapTextWithPrefix(
+							opts.output,
+							submitText,
+							hasGuide ? `${styleText('gray', S_BAR)}  ` : ''
+						);
+						return `${title}${wrappedSubmitText}`;
+					}
+					case 'cancel': {
+						const label = this.options
+							.filter(({ value: optionValue }) => value.includes(optionValue))
+							.map((option) => opt(option, 'cancelled'))
+							.join(styleText('dim', ', '));
+						if (label.trim() === '') {
+							return `${title}${styleText('gray', S_BAR)}`;
+						}
+						const wrappedLabel = wrapTextWithPrefix(
+							opts.output,
+							label,
+							hasGuide ? `${styleText('gray', S_BAR)}  ` : ''
+						);
+						return `${title}${wrappedLabel}${hasGuide ? `\n${styleText('gray', S_BAR)}` : ''}`;
+					}
+					case 'error': {
+						const prefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
+						const footer = this.error
+							.split('\n')
+							.map((ln, i) =>
+								i === 0
+									? `${hasGuide ? `${styleText('yellow', S_BAR_END)}  ` : ''}${styleText('yellow', ln)}`
+									: `   ${ln}`
+							)
+							.join('\n');
+						// Calculate rowPadding: title lines + footer lines (error message + trailing newline)
+						const titleLineCount = title.split('\n').length;
+						const footerLineCount = footer.split('\n').length + 1; // footer + trailing newline
+						return `${title}${prefix}${limitOptions({
+							output: opts.output,
+							options: this.options,
+							cursor: this.cursor,
+							maxItems: opts.maxItems,
+							columnPadding: prefix.length,
+							rowPadding: titleLineCount + footerLineCount,
+							style: styleOption,
+						}).join(`\n${prefix}`)}\n${footer}\n`;
+					}
+					default: {
+						const prefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						// Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
+						const titleLineCount = title.split('\n').length;
+						const footerLineCount = hasGuide ? 2 : 1; // S_BAR_END + trailing newline
+						return `${title}${prefix}${limitOptions({
+							output: opts.output,
+							options: this.options,
+							cursor: this.cursor,
+							maxItems: opts.maxItems,
+							columnPadding: prefix.length,
+							rowPadding: titleLineCount + footerLineCount,
+							style: styleOption,
+						}).join(`\n${prefix}`)}\n${hasGuide ? styleText('cyan', S_BAR_END) : ''}\n`;
+					}
 				}
-				default: {
-					const prefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					// Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
-					const titleLineCount = title.split('\n').length;
-					const footerLineCount = hasGuide ? 2 : 1; // S_BAR_END + trailing newline
-					return `${title}${prefix}${limitOptions({
-						output: opts.output,
-						options: this.options,
-						cursor: this.cursor,
-						maxItems: opts.maxItems,
-						columnPadding: prefix.length,
-						rowPadding: titleLineCount + footerLineCount,
-						style: styleOption,
-					}).join(`\n${prefix}`)}\n${hasGuide ? styleText('cyan', S_BAR_END) : ''}\n`;
-				}
-			}
-		},
-	}).prompt() as Promise<Value[] | symbol>;
-};
+			},
+		}).prompt() as Promise<Value[] | symbol>,
+		opts.onCancel
+	);
+}

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -1,7 +1,14 @@
 import { styleText } from 'node:util';
 import type { Validate } from '@clack/core';
 import { PasswordPrompt, settings } from '@clack/core';
-import { type CommonOptions, S_BAR, S_BAR_END, S_PASSWORD_MASK, symbol } from './common.js';
+import {
+	type CommonOptions,
+	handleCancel,
+	S_BAR,
+	S_BAR_END,
+	S_PASSWORD_MASK,
+	symbol,
+} from './common.js';
 
 /**
  * Options for the {@link password} prompt
@@ -46,47 +53,52 @@ export interface PasswordOptions extends CommonOptions {
  * });
  * ```
  */
-export const password = (opts: PasswordOptions) => {
-	return new PasswordPrompt({
-		validate: opts.validate,
-		mask: opts.mask ?? S_PASSWORD_MASK,
-		signal: opts.signal,
-		input: opts.input,
-		output: opts.output,
-		render() {
-			const hasGuide = opts.withGuide ?? settings.withGuide;
-			const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
-			const userInput = this.userInputWithCursor;
-			const masked = this.masked;
+export function password(opts: PasswordOptions & { onCancel: () => never }): Promise<string>;
+export function password(opts: PasswordOptions): Promise<string | symbol>;
+export function password(opts: PasswordOptions): Promise<string | symbol> {
+	return handleCancel(
+		new PasswordPrompt({
+			validate: opts.validate,
+			mask: opts.mask ?? S_PASSWORD_MASK,
+			signal: opts.signal,
+			input: opts.input,
+			output: opts.output,
+			render() {
+				const hasGuide = opts.withGuide ?? settings.withGuide;
+				const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
+				const userInput = this.userInputWithCursor;
+				const masked = this.masked;
 
-			switch (this.state) {
-				case 'error': {
-					const errorPrefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
-					const errorPrefixEnd = hasGuide ? `${styleText('yellow', S_BAR_END)}  ` : '';
-					const maskedText = masked ?? '';
-					if (opts.clearOnError) {
-						this.clear();
+				switch (this.state) {
+					case 'error': {
+						const errorPrefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
+						const errorPrefixEnd = hasGuide ? `${styleText('yellow', S_BAR_END)}  ` : '';
+						const maskedText = masked ?? '';
+						if (opts.clearOnError) {
+							this.clear();
+						}
+						return `${title.trim()}\n${errorPrefix}${maskedText}\n${errorPrefixEnd}${styleText('yellow', this.error)}\n`;
 					}
-					return `${title.trim()}\n${errorPrefix}${maskedText}\n${errorPrefixEnd}${styleText('yellow', this.error)}\n`;
+					case 'submit': {
+						const submitPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+						const maskedText = masked ? styleText('dim', masked) : '';
+						return `${title}${submitPrefix}${maskedText}`;
+					}
+					case 'cancel': {
+						const cancelPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+						const maskedText = masked ? styleText(['strikethrough', 'dim'], masked) : '';
+						return `${title}${cancelPrefix}${maskedText}${
+							masked && hasGuide ? `\n${styleText('gray', S_BAR)}` : ''
+						}`;
+					}
+					default: {
+						const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
+						return `${title}${defaultPrefix}${userInput}\n${defaultPrefixEnd}\n`;
+					}
 				}
-				case 'submit': {
-					const submitPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-					const maskedText = masked ? styleText('dim', masked) : '';
-					return `${title}${submitPrefix}${maskedText}`;
-				}
-				case 'cancel': {
-					const cancelPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-					const maskedText = masked ? styleText(['strikethrough', 'dim'], masked) : '';
-					return `${title}${cancelPrefix}${maskedText}${
-						masked && hasGuide ? `\n${styleText('gray', S_BAR)}` : ''
-					}`;
-				}
-				default: {
-					const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
-					return `${title}${defaultPrefix}${userInput}\n${defaultPrefixEnd}\n`;
-				}
-			}
-		},
-	}).prompt() as Promise<string | symbol>;
-};
+			},
+		}).prompt() as Promise<string | symbol>,
+		opts.onCancel
+	);
+}

--- a/packages/prompts/src/path.ts
+++ b/packages/prompts/src/path.ts
@@ -58,7 +58,9 @@ export interface PathOptions extends CommonOptions {
  * });
  * ```
  */
-export const path = (opts: PathOptions) => {
+export function path(opts: PathOptions & { onCancel: () => never }): Promise<string>;
+export function path(opts: PathOptions): Promise<string | symbol>;
+export function path(opts: PathOptions): Promise<string | symbol> {
 	const validate = opts.validate;
 
 	return autocomplete({
@@ -124,4 +126,4 @@ export const path = (opts: PathOptions) => {
 			}
 		},
 	});
-};
+}

--- a/packages/prompts/src/select-key.ts
+++ b/packages/prompts/src/select-key.ts
@@ -1,6 +1,6 @@
 import { styleText } from 'node:util';
 import { SelectKeyPrompt, settings, wrapTextWithPrefix } from '@clack/core';
-import { type CommonOptions, S_BAR, S_BAR_END, symbol } from './common.js';
+import { type CommonOptions, handleCancel, S_BAR, S_BAR_END, symbol } from './common.js';
 import type { Option } from './select.js';
 
 export interface SelectKeyOptions<Value extends string> extends CommonOptions {
@@ -10,7 +10,15 @@ export interface SelectKeyOptions<Value extends string> extends CommonOptions {
 	caseSensitive?: boolean;
 }
 
-export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) => {
+export function selectKey<Value extends string>(
+	opts: SelectKeyOptions<Value> & { onCancel: () => never }
+): Promise<Value>;
+export function selectKey<Value extends string>(
+	opts: SelectKeyOptions<Value>
+): Promise<Value | symbol>;
+export function selectKey<Value extends string>(
+	opts: SelectKeyOptions<Value>
+): Promise<Value | symbol> {
 	const opt = (
 		option: Option<Value>,
 		state: 'inactive' | 'active' | 'selected' | 'cancelled' = 'inactive'
@@ -32,53 +40,56 @@ export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) =
 		}`;
 	};
 
-	return new SelectKeyPrompt({
-		options: opts.options,
-		signal: opts.signal,
-		input: opts.input,
-		output: opts.output,
-		initialValue: opts.initialValue,
-		caseSensitive: opts.caseSensitive,
-		render() {
-			const hasGuide = opts.withGuide ?? settings.withGuide;
-			const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
+	return handleCancel(
+		new SelectKeyPrompt({
+			options: opts.options,
+			signal: opts.signal,
+			input: opts.input,
+			output: opts.output,
+			initialValue: opts.initialValue,
+			caseSensitive: opts.caseSensitive,
+			render() {
+				const hasGuide = opts.withGuide ?? settings.withGuide;
+				const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
 
-			switch (this.state) {
-				case 'submit': {
-					const submitPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-					const selectedOption =
-						this.options.find((opt) => opt.value === this.value) ?? opts.options[0];
-					const wrapped = wrapTextWithPrefix(
-						opts.output,
-						opt(selectedOption, 'selected'),
-						submitPrefix
-					);
-					return `${title}${wrapped}`;
-				}
-				case 'cancel': {
-					const cancelPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-					const wrapped = wrapTextWithPrefix(
-						opts.output,
-						opt(this.options[0], 'cancelled'),
-						cancelPrefix
-					);
-					return `${title}${wrapped}${hasGuide ? `\n${styleText('gray', S_BAR)}` : ''}`;
-				}
-				default: {
-					const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
-					const wrapped = this.options
-						.map((option, i) =>
-							wrapTextWithPrefix(
-								opts.output,
-								opt(option, i === this.cursor ? 'active' : 'inactive'),
-								defaultPrefix
+				switch (this.state) {
+					case 'submit': {
+						const submitPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+						const selectedOption =
+							this.options.find((opt) => opt.value === this.value) ?? opts.options[0];
+						const wrapped = wrapTextWithPrefix(
+							opts.output,
+							opt(selectedOption, 'selected'),
+							submitPrefix
+						);
+						return `${title}${wrapped}`;
+					}
+					case 'cancel': {
+						const cancelPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+						const wrapped = wrapTextWithPrefix(
+							opts.output,
+							opt(this.options[0], 'cancelled'),
+							cancelPrefix
+						);
+						return `${title}${wrapped}${hasGuide ? `\n${styleText('gray', S_BAR)}` : ''}`;
+					}
+					default: {
+						const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
+						const wrapped = this.options
+							.map((option, i) =>
+								wrapTextWithPrefix(
+									opts.output,
+									opt(option, i === this.cursor ? 'active' : 'inactive'),
+									defaultPrefix
+								)
 							)
-						)
-						.join('\n');
-					return `${title}${wrapped}\n${defaultPrefixEnd}\n`;
+							.join('\n');
+						return `${title}${wrapped}\n${defaultPrefixEnd}\n`;
+					}
 				}
-			}
-		},
-	}).prompt() as Promise<Value | symbol>;
-};
+			},
+		}).prompt() as Promise<Value | symbol>,
+		opts.onCancel
+	);
+}

--- a/packages/prompts/src/select.ts
+++ b/packages/prompts/src/select.ts
@@ -2,6 +2,7 @@ import { styleText } from 'node:util';
 import { SelectPrompt, settings, wrapTextWithPrefix } from '@clack/core';
 import {
 	type CommonOptions,
+	handleCancel,
 	S_BAR,
 	S_BAR_END,
 	S_RADIO_ACTIVE,
@@ -82,7 +83,11 @@ const computeLabel = (label: string, format: (text: string) => string) => {
 		.join('\n');
 };
 
-export const select = <Value>(opts: SelectOptions<Value>) => {
+export function select<Value>(
+	opts: SelectOptions<Value> & { onCancel: () => never }
+): Promise<Value>;
+export function select<Value>(opts: SelectOptions<Value>): Promise<Value | symbol>;
+export function select<Value>(opts: SelectOptions<Value>): Promise<Value | symbol> {
 	const opt = (
 		option: Option<Value>,
 		state: 'inactive' | 'active' | 'selected' | 'cancelled' | 'disabled'
@@ -106,61 +111,64 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 		}
 	};
 
-	return new SelectPrompt({
-		options: opts.options,
-		signal: opts.signal,
-		input: opts.input,
-		output: opts.output,
-		initialValue: opts.initialValue,
-		render() {
-			const hasGuide = opts.withGuide ?? settings.withGuide;
-			const titlePrefix = `${symbol(this.state)}  `;
-			const titlePrefixBar = `${symbolBar(this.state)}  `;
-			const messageLines = wrapTextWithPrefix(
-				opts.output,
-				opts.message,
-				titlePrefixBar,
-				titlePrefix
-			);
-			const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${messageLines}\n`;
+	return handleCancel(
+		new SelectPrompt({
+			options: opts.options,
+			signal: opts.signal,
+			input: opts.input,
+			output: opts.output,
+			initialValue: opts.initialValue,
+			render() {
+				const hasGuide = opts.withGuide ?? settings.withGuide;
+				const titlePrefix = `${symbol(this.state)}  `;
+				const titlePrefixBar = `${symbolBar(this.state)}  `;
+				const messageLines = wrapTextWithPrefix(
+					opts.output,
+					opts.message,
+					titlePrefixBar,
+					titlePrefix
+				);
+				const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${messageLines}\n`;
 
-			switch (this.state) {
-				case 'submit': {
-					const submitPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-					const wrappedLines = wrapTextWithPrefix(
-						opts.output,
-						opt(this.options[this.cursor], 'selected'),
-						submitPrefix
-					);
-					return `${title}${wrappedLines}`;
+				switch (this.state) {
+					case 'submit': {
+						const submitPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+						const wrappedLines = wrapTextWithPrefix(
+							opts.output,
+							opt(this.options[this.cursor], 'selected'),
+							submitPrefix
+						);
+						return `${title}${wrappedLines}`;
+					}
+					case 'cancel': {
+						const cancelPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
+						const wrappedLines = wrapTextWithPrefix(
+							opts.output,
+							opt(this.options[this.cursor], 'cancelled'),
+							cancelPrefix
+						);
+						return `${title}${wrappedLines}${hasGuide ? `\n${styleText('gray', S_BAR)}` : ''}`;
+					}
+					default: {
+						const prefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						const prefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
+						// Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
+						const titleLineCount = title.split('\n').length;
+						const footerLineCount = hasGuide ? 2 : 1; // S_BAR_END + trailing newline (or just trailing newline)
+						return `${title}${prefix}${limitOptions({
+							output: opts.output,
+							cursor: this.cursor,
+							options: this.options,
+							maxItems: opts.maxItems,
+							columnPadding: prefix.length,
+							rowPadding: titleLineCount + footerLineCount,
+							style: (item, active) =>
+								opt(item, item.disabled ? 'disabled' : active ? 'active' : 'inactive'),
+						}).join(`\n${prefix}`)}\n${prefixEnd}\n`;
+					}
 				}
-				case 'cancel': {
-					const cancelPrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : '';
-					const wrappedLines = wrapTextWithPrefix(
-						opts.output,
-						opt(this.options[this.cursor], 'cancelled'),
-						cancelPrefix
-					);
-					return `${title}${wrappedLines}${hasGuide ? `\n${styleText('gray', S_BAR)}` : ''}`;
-				}
-				default: {
-					const prefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const prefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
-					// Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
-					const titleLineCount = title.split('\n').length;
-					const footerLineCount = hasGuide ? 2 : 1; // S_BAR_END + trailing newline (or just trailing newline)
-					return `${title}${prefix}${limitOptions({
-						output: opts.output,
-						cursor: this.cursor,
-						options: this.options,
-						maxItems: opts.maxItems,
-						columnPadding: prefix.length,
-						rowPadding: titleLineCount + footerLineCount,
-						style: (item, active) =>
-							opt(item, item.disabled ? 'disabled' : active ? 'active' : 'inactive'),
-					}).join(`\n${prefix}`)}\n${prefixEnd}\n`;
-				}
-			}
-		},
-	}).prompt() as Promise<Value | symbol>;
-};
+			},
+		}).prompt() as Promise<Value | symbol>,
+		opts.onCancel
+	);
+}

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -1,7 +1,7 @@
 import { styleText } from 'node:util';
 import type { Validate } from '@clack/core';
 import { settings, TextPrompt } from '@clack/core';
-import { type CommonOptions, S_BAR, S_BAR_END, symbol } from './common.js';
+import { type CommonOptions, handleCancel, S_BAR, S_BAR_END, symbol } from './common.js';
 
 /**
  * Options for the {@link text} prompt
@@ -55,48 +55,53 @@ export interface TextOptions extends CommonOptions {
  * });
  * ```
  */
-export const text = (opts: TextOptions) => {
-	return new TextPrompt({
-		validate: opts.validate,
-		placeholder: opts.placeholder,
-		defaultValue: opts.defaultValue,
-		initialValue: opts.initialValue,
-		output: opts.output,
-		signal: opts.signal,
-		input: opts.input,
-		render() {
-			const hasGuide = opts?.withGuide ?? settings.withGuide;
-			const titlePrefix = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  `;
-			const title = `${titlePrefix}${opts.message}\n`;
-			const placeholder = opts.placeholder
-				? styleText('inverse', opts.placeholder[0]) + styleText('dim', opts.placeholder.slice(1))
-				: styleText(['inverse', 'hidden'], '_');
-			const userInput = !this.userInput ? placeholder : this.userInputWithCursor;
-			const value = this.value ?? '';
+export function text(opts: TextOptions & { onCancel: () => never }): Promise<string>;
+export function text(opts: TextOptions): Promise<string | symbol>;
+export function text(opts: TextOptions): Promise<string | symbol> {
+	return handleCancel(
+		new TextPrompt({
+			validate: opts.validate,
+			placeholder: opts.placeholder,
+			defaultValue: opts.defaultValue,
+			initialValue: opts.initialValue,
+			output: opts.output,
+			signal: opts.signal,
+			input: opts.input,
+			render() {
+				const hasGuide = opts?.withGuide ?? settings.withGuide;
+				const titlePrefix = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${symbol(this.state)}  `;
+				const title = `${titlePrefix}${opts.message}\n`;
+				const placeholder = opts.placeholder
+					? styleText('inverse', opts.placeholder[0]) + styleText('dim', opts.placeholder.slice(1))
+					: styleText(['inverse', 'hidden'], '_');
+				const userInput = !this.userInput ? placeholder : this.userInputWithCursor;
+				const value = this.value ?? '';
 
-			switch (this.state) {
-				case 'error': {
-					const errorText = this.error ? `  ${styleText('yellow', this.error)}` : '';
-					const errorPrefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
-					const errorPrefixEnd = hasGuide ? styleText('yellow', S_BAR_END) : '';
-					return `${title.trim()}\n${errorPrefix}${userInput}\n${errorPrefixEnd}${errorText}\n`;
+				switch (this.state) {
+					case 'error': {
+						const errorText = this.error ? `  ${styleText('yellow', this.error)}` : '';
+						const errorPrefix = hasGuide ? `${styleText('yellow', S_BAR)}  ` : '';
+						const errorPrefixEnd = hasGuide ? styleText('yellow', S_BAR_END) : '';
+						return `${title.trim()}\n${errorPrefix}${userInput}\n${errorPrefixEnd}${errorText}\n`;
+					}
+					case 'submit': {
+						const valueText = value ? `  ${styleText('dim', value)}` : '';
+						const submitPrefix = hasGuide ? styleText('gray', S_BAR) : '';
+						return `${title}${submitPrefix}${valueText}`;
+					}
+					case 'cancel': {
+						const valueText = value ? `  ${styleText(['strikethrough', 'dim'], value)}` : '';
+						const cancelPrefix = hasGuide ? styleText('gray', S_BAR) : '';
+						return `${title}${cancelPrefix}${valueText}${value.trim() ? `\n${cancelPrefix}` : ''}`;
+					}
+					default: {
+						const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
+						const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
+						return `${title}${defaultPrefix}${userInput}\n${defaultPrefixEnd}\n`;
+					}
 				}
-				case 'submit': {
-					const valueText = value ? `  ${styleText('dim', value)}` : '';
-					const submitPrefix = hasGuide ? styleText('gray', S_BAR) : '';
-					return `${title}${submitPrefix}${valueText}`;
-				}
-				case 'cancel': {
-					const valueText = value ? `  ${styleText(['strikethrough', 'dim'], value)}` : '';
-					const cancelPrefix = hasGuide ? styleText('gray', S_BAR) : '';
-					return `${title}${cancelPrefix}${valueText}${value.trim() ? `\n${cancelPrefix}` : ''}`;
-				}
-				default: {
-					const defaultPrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const defaultPrefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : '';
-					return `${title}${defaultPrefix}${userInput}\n${defaultPrefixEnd}\n`;
-				}
-			}
-		},
-	}).prompt() as Promise<string | symbol>;
-};
+			},
+		}).prompt() as Promise<string | symbol>,
+		opts.onCancel
+	);
+}

--- a/packages/prompts/test/onCancel.test.ts
+++ b/packages/prompts/test/onCancel.test.ts
@@ -1,0 +1,382 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as prompts from '../src/index.js';
+import { MockReadable, MockWritable } from './test-utils.js';
+
+const cancelKey = { name: 'escape' } as const;
+const submitKey = { name: 'return' } as const;
+
+describe('onCancel', () => {
+	let originalCI: string | undefined;
+	let output: MockWritable;
+	let input: MockReadable;
+
+	beforeAll(() => {
+		originalCI = process.env.CI;
+		process.env.CI = 'true';
+	});
+
+	afterAll(() => {
+		process.env.CI = originalCI;
+	});
+
+	beforeEach(() => {
+		output = new MockWritable();
+		input = new MockReadable();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('confirm', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.confirm({ message: 'q', onCancel, input, output });
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.confirm({ message: 'q', onCancel, input, output });
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(value).toBe(true);
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('text', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.text({ message: 'q', onCancel, input, output });
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.text({ message: 'q', onCancel, input, output });
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(typeof value).toBe('string');
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('select', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.select({
+				message: 'q',
+				options: [{ value: 'a' }, { value: 'b' }],
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.select({
+				message: 'q',
+				options: [{ value: 'a' }, { value: 'b' }],
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(value).toBe('a');
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('multiselect', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.multiselect({
+				message: 'q',
+				options: [{ value: 'a' }, { value: 'b' }],
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.multiselect({
+				message: 'q',
+				options: [{ value: 'a' }, { value: 'b' }],
+				required: false,
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(Array.isArray(value)).toBe(true);
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('groupMultiselect', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.groupMultiselect({
+				message: 'q',
+				options: { group: [{ value: 'a' }] },
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.groupMultiselect({
+				message: 'q',
+				options: { group: [{ value: 'a' }] },
+				required: false,
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(Array.isArray(value)).toBe(true);
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('password', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.password({ message: 'q', onCancel, input, output });
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.password({ message: 'q', onCancel, input, output });
+			input.emit('keypress', 'x', { name: 'x' });
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(value).toBe('x');
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('selectKey', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.selectKey({
+				message: 'q',
+				options: [{ value: 'a' as const }, { value: 'b' as const }],
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.selectKey({
+				message: 'q',
+				options: [{ value: 'a' as const }, { value: 'b' as const }],
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'a', { name: 'a' });
+			const value = await result;
+			expect(value).toBe('a');
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('date', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.date({
+				message: 'q',
+				locale: 'en-US',
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const d = new Date(Date.UTC(2025, 0, 15));
+			const result = prompts.date({
+				message: 'q',
+				locale: 'en-US',
+				initialValue: d,
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', undefined, submitKey);
+			const value = await result;
+			expect(value).toBeInstanceOf(Date);
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('multiline', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.multiline({ message: 'q', onCancel, input, output });
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.multiline({ message: 'q', onCancel, input, output });
+			input.emit('keypress', '', submitKey);
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(typeof value).toBe('string');
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('path', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.path({
+				message: 'q',
+				root: '/tmp/',
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.path({
+				message: 'q',
+				root: '/tmp/',
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(typeof value).toBe('string');
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('autocomplete', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.autocomplete({
+				message: 'q',
+				options: [{ value: 'a' }, { value: 'b' }],
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.autocomplete({
+				message: 'q',
+				options: [{ value: 'a' }, { value: 'b' }],
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(value).toBe('a');
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('autocompleteMultiselect', () => {
+		test('calls onCancel when cancelled', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.autocompleteMultiselect({
+				message: 'q',
+				options: [{ value: 'a' }, { value: 'b' }],
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCancel on submit', async () => {
+			const onCancel = vi.fn();
+			const result = prompts.autocompleteMultiselect({
+				message: 'q',
+				options: [{ value: 'a' }, { value: 'b' }],
+				required: false,
+				onCancel,
+				input,
+				output,
+			});
+			input.emit('keypress', '', submitKey);
+			const value = await result;
+			expect(Array.isArray(value)).toBe(true);
+			expect(onCancel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('handleCancel utility', () => {
+		test('resolves with cancel symbol when no onCancel provided', async () => {
+			const result = prompts.text({ message: 'q', input, output });
+			input.emit('keypress', 'escape', cancelKey);
+			const value = await result;
+			expect(prompts.isCancel(value)).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds an optional `onCancel` callback to all prompt functions via `CommonOptions`. When the user cancels a prompt (Ctrl+C or Escape), the callback is invoked — eliminating the need for `isCancel` guards at every call site. **When `onCancel` is provided, the return type narrows from `Promise<T | symbol>` to `Promise<T>`.**

Closes #83

## Motivation

Every clack user repeats this pattern:

```ts
const result = await confirm({ message: "Continue?" });
if (isCancel(result)) {
  cancel("Operation cancelled.");
  process.exit(0);
}
```

This PR makes it:

```ts
const result = await confirm({
  message: "Continue?",
  onCancel: () => {
    cancel("Operation cancelled.");
    process.exit(0);
  },
});
// result is `boolean` — no isCancel guard needed
```

## Changes

- **`CommonOptions`** — added `onCancel?: () => void`
- **`handleCancel` utility** — exported from `@clack/prompts` for custom prompt implementations
- **All 12 prompt functions** — converted to function declarations with overloads for return type narrowing
- **Tests** — runtime tests for cancel behavior + compile-time type narrowing tests

## Type narrowing

Each prompt uses function overloads so TypeScript narrows the return type when `onCancel` is present:

```ts
// Without onCancel: result is boolean | symbol
const a = await confirm({ message: "Continue?" });
//    ^? boolean | symbol

// With onCancel: result is boolean (narrowed)
const b = await confirm({ message: "Continue?", onCancel: () => { process.exit(0); } });
//    ^? boolean
```

This works for all prompts: `text`, `confirm`, `select`, `multiselect`, `groupMultiselect`, `password`, `autocomplete`, `autocompleteMultiselect`, `selectKey`, `date`, `multiline`, `path`.

## Design decisions

- **Additive, no breaking changes** — `onCancel` is optional; existing code works unchanged
- **Function overloads for narrowing** — the idiomatic TypeScript pattern; converts `export const` arrows to `export function` declarations
- **`handleCancel` is exported** — useful for custom prompt implementations

## Test plan

- [x] All 727 existing + new tests pass
- [x] `pnpm run build` succeeds
- [x] `pnpm run types` succeeds
- [x] `pnpm run lint` succeeds
- [x] `pnpm run format` succeeds
- [x] Type narrowing verified via compile-time assertions (`@ts-expect-error`)