### PR TITLE
chore: remove sourcemaps & enable prettier output

### DIFF
--- a/.changeset/great-rabbits-check.md
+++ b/.changeset/great-rabbits-check.md
@@ -1,0 +1,6 @@
+---
+"@clack/core": patch
+"@clack/prompts": patch
+---
+
+Remove sourcemaps and enable pretty-ish build output.

--- a/build.preset.ts
+++ b/build.preset.ts
@@ -4,12 +4,14 @@ import { definePreset } from 'unbuild';
 export default definePreset({
 	clean: true,
 	declaration: 'node16',
-	sourcemap: true,
+	sourcemap: false,
 	rollup: {
 		emitCJS: false,
 		inlineDependencies: true,
 		esbuild: {
-			minify: true,
+			minifySyntax: true,
+			minifyIdentifiers: true,
+			minifyWhitespace: false
 		},
 	},
 });


### PR DESCRIPTION
This removes sourcemaps to greatly reduce the install size.

To account for the fact the occasional person might step their debugger
into this, I've also disabled `minifyWhitespace` so the build output is
readable at least.

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
