### PR TITLE
fix: normalize password prompt empty submit to empty string (#560)

### DIFF
--- a/.changeset/password-empty-submit.md
+++ b/.changeset/password-empty-submit.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": patch
+---
+
+Fix `password` prompt resolving to `undefined` on empty submit. It now normalizes an empty submission to `""`, matching the `text` prompt behavior and the documented `Promise<string | symbol>` return type.

--- a/packages/core/src/prompts/password.ts
+++ b/packages/core/src/prompts/password.ts
@@ -34,5 +34,10 @@ export default class PasswordPrompt extends Prompt<string> {
 		this.on('userInput', (input) => {
 			this._setValue(input);
 		});
+		this.on('finalize', () => {
+			if (this.value === undefined) {
+				this.value = '';
+			}
+		});
 	}
 }

--- a/packages/core/test/prompts/password.test.ts
+++ b/packages/core/test/prompts/password.test.ts
@@ -29,6 +29,18 @@ describe('PasswordPrompt', () => {
 		expect(output.buffer).to.deep.equal([cursor.hide, 'foo']);
 	});
 
+	test('returns empty string on empty submit', async () => {
+		const instance = new PasswordPrompt({
+			input,
+			output,
+			render: () => 'foo',
+		});
+		const resultPromise = instance.prompt();
+		input.emit('keypress', '', { name: 'return' });
+		const result = await resultPromise;
+		expect(result).to.equal('');
+	});
+
 	describe('cursor', () => {
 		test('can get cursor', () => {
 			const instance = new PasswordPrompt({


### PR DESCRIPTION
## What does this PR do?

The password prompt resolved to undefined on empty submit instead of empty string. Normalize the value on finalize to match the text prompt and the documented Promise<string | symbol> return type.

Closes #560

## Type of change

<!-- Check one. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code
