### PR TITLE
fix(core): seed multiline prompt with initialValue

### DIFF
--- a/.changeset/multiline-initial-value.md
+++ b/.changeset/multiline-initial-value.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": patch
+---
+
+Fix `multiline` prompt ignoring `initialValue`. The editor is now seeded with `initialValue` (falling back to `initialUserInput`) when the prompt opens, matching the `text` prompt.

--- a/packages/core/src/prompts/multi-line.ts
+++ b/packages/core/src/prompts/multi-line.ts
@@ -87,7 +87,13 @@ export default class MultiLinePrompt extends Prompt<string> {
 	}
 
 	constructor(opts: MultiLineOptions) {
-		super(opts, false);
+		super(
+			{
+				...opts,
+				initialUserInput: opts.initialUserInput ?? opts.initialValue,
+			},
+			false
+		);
 		this.#showSubmit = opts.showSubmit ?? false;
 
 		this.on('key', (char, key) => {

--- a/packages/core/test/prompts/multi-line.test.ts
+++ b/packages/core/test/prompts/multi-line.test.ts
@@ -57,6 +57,32 @@ describe('MultiLinePrompt', () => {
 		expect(result).to.equal('x');
 	});
 
+	test('seeds initialValue into the editor', () => {
+		const instance = new MultiLinePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			initialValue: 'first line\nsecond line',
+		});
+		instance.prompt();
+		expect(instance.userInput).to.equal('first line\nsecond line');
+		expect(instance.value).to.equal('first line\nsecond line');
+	});
+
+	test('submits initialValue when not edited', async () => {
+		const instance = new MultiLinePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			initialValue: 'untouched',
+		});
+		const resultPromise = instance.prompt();
+		input.emit('keypress', '', { name: 'return' });
+		input.emit('keypress', '', { name: 'return' });
+		const result = await resultPromise;
+		expect(result).to.equal('untouched');
+	});
+
 	describe('cursor', () => {
 		test('can get cursor', () => {
 			const instance = new MultiLinePrompt({


### PR DESCRIPTION
Closes #566.

`multiline` accepts `initialValue` but never seeded the editor with it, so passing it had no effect — the prompt always opened empty.

`TextPrompt` forwards `initialValue` to the base `Prompt` as `initialUserInput`; `MultiLinePrompt` did not. This mirrors that single line in the `MultiLinePrompt` constructor, so the editor opens pre-filled and an unedited submit returns the seeded value (falling back to `initialUserInput`).

### Tests
Two `@clack/core` tests, red before the change and green after:
- seeds `initialValue` into the editor (`userInput` + `value`)
- submits `initialValue` when not edited

Full `@clack/core` suite: 143 passing. Changeset included (`@clack/core` patch).