### PR TITLE
feat(prompts): add showInstructions opt-out

### DIFF
--- a/.changeset/fresh-facts-search.md
+++ b/.changeset/fresh-facts-search.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": minor
+---
+
+Add `showInstructions` option to `select`, `multiselect`, and `groupMultiselect`. Keyboard hints remain shown by default; pass `showInstructions: false` to hide them.

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -60,6 +60,12 @@ export interface GroupMultiSelectOptions<Value> extends CommonOptions {
 	 * @default 0
 	 */
 	groupSpacing?: number;
+
+	/**
+	 * Show keyboard instructions below the option list.
+	 * @default true
+	 */
+	showInstructions?: boolean;
 }
 
 /**
@@ -191,6 +197,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 		);
 	};
 	const required = opts.required ?? true;
+	const showInstructions = opts.showInstructions ?? true;
 
 	return new GroupMultiSelectPrompt({
 		options: opts.options,
@@ -288,7 +295,11 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 				default: {
 					const guidePrefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
 					const titleLineCount = title.split('\n').length;
-					const footerLines = formatInstructionFooter(MULTISELECT_INSTRUCTIONS, hasGuide);
+					const footerLines = showInstructions
+						? formatInstructionFooter(MULTISELECT_INSTRUCTIONS, hasGuide)
+						: hasGuide
+							? [styleText('cyan', S_BAR_END)]
+							: [];
 					const footerText = footerLines.join('\n');
 					const footerLineCount = footerLines.length + 1;
 					const optionsText = limitOptions({

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -27,6 +27,11 @@ export interface MultiSelectOptions<Value> extends CommonOptions {
 	maxItems?: number;
 	required?: boolean;
 	cursorAt?: Value;
+	/**
+	 * Show keyboard instructions below the option list.
+	 * @default true
+	 */
+	showInstructions?: boolean;
 }
 const computeLabel = (label: string, format: (text: string) => string) => {
 	return label
@@ -77,6 +82,7 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 		return `${styleText('dim', S_CHECKBOX_INACTIVE)} ${computeLabel(label, (text) => styleText('dim', text))}`;
 	};
 	const required = opts.required ?? true;
+	const showInstructions = opts.showInstructions ?? true;
 
 	return new MultiSelectPrompt({
 		options: opts.options,
@@ -179,7 +185,11 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 				default: {
 					const prefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
 					const titleLineCount = title.split('\n').length;
-					const footerLines = formatInstructionFooter(MULTISELECT_INSTRUCTIONS, hasGuide);
+					const footerLines = showInstructions
+						? formatInstructionFooter(MULTISELECT_INSTRUCTIONS, hasGuide)
+						: hasGuide
+							? [styleText('cyan', S_BAR_END)]
+							: [];
 					const footerText = footerLines.join('\n');
 					const footerLineCount = footerLines.length + 1;
 					return `${title}${prefix}${limitOptions({

--- a/packages/prompts/src/select.ts
+++ b/packages/prompts/src/select.ts
@@ -4,6 +4,7 @@ import {
 	type CommonOptions,
 	formatInstructionFooter,
 	S_BAR,
+	S_BAR_END,
 	S_RADIO_ACTIVE,
 	S_RADIO_INACTIVE,
 	symbol,
@@ -75,6 +76,11 @@ export interface SelectOptions<Value> extends CommonOptions {
 	options: Option<Value>[];
 	initialValue?: Value;
 	maxItems?: number;
+	/**
+	 * Show keyboard instructions below the option list.
+	 * @default true
+	 */
+	showInstructions?: boolean;
 }
 
 const computeLabel = (label: string, format: (text: string) => string) => {
@@ -110,6 +116,8 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 				return `${styleText('dim', S_RADIO_INACTIVE)} ${computeLabel(label, (text) => styleText('dim', text))}`;
 		}
 	};
+
+	const showInstructions = opts.showInstructions ?? true;
 
 	return new SelectPrompt({
 		options: opts.options,
@@ -151,7 +159,11 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 				default: {
 					const prefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
 					const titleLineCount = title.split('\n').length;
-					const footerLines = formatInstructionFooter(SELECT_INSTRUCTIONS, hasGuide);
+					const footerLines = showInstructions
+						? formatInstructionFooter(SELECT_INSTRUCTIONS, hasGuide)
+						: hasGuide
+							? [styleText('cyan', S_BAR_END)]
+							: [];
 					const footerText = footerLines.join('\n');
 					const footerLineCount = footerLines.length + 1;
 					return `${title}${prefix}${limitOptions({

--- a/packages/prompts/test/__snapshots__/group-multi-select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/group-multi-select.test.ts.snap
@@ -664,6 +664,27 @@ exports[`groupMultiselect (isCI = false) > selectableGroups = false > selecting 
 ]
 `;
 
+exports[`groupMultiselect (isCI = false) > showInstructions: false hides instruction footer 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  └ [36m◻[39m [2mgroup1value1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`groupMultiselect (isCI = false) > sliding window loops downwards 1`] = `
 [
   "<cursor.hide>",
@@ -1625,6 +1646,27 @@ exports[`groupMultiselect (isCI = true) > selectableGroups = false > selecting a
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mgroup1value0[22m[2m, [22m[2mgroup1value1[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`groupMultiselect (isCI = true) > showInstructions: false hides instruction footer 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  └ [36m◻[39m [2mgroup1value1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/multi-select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/multi-select.test.ts.snap
@@ -575,6 +575,26 @@ exports[`multiselect (isCI = false) > renders validation errors 1`] = `
 ]
 `;
 
+exports[`multiselect (isCI = false) > showInstructions: false hides instruction footer 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [36m◻[39m opt0
+[36m│[39m  [2m◻[22m [2mopt1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mnone[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`multiselect (isCI = false) > shows hints for all selected options 1`] = `
 [
   "<cursor.hide>",
@@ -1508,6 +1528,26 @@ exports[`multiselect (isCI = true) > renders validation errors 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mopt0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`multiselect (isCI = true) > showInstructions: false hides instruction footer 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [36m◻[39m opt0
+[36m│[39m  [2m◻[22m [2mopt1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mnone[22m",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/select.test.ts.snap
@@ -461,6 +461,26 @@ exports[`select (isCI = false) > renders options and message 1`] = `
 ]
 `;
 
+exports[`select (isCI = false) > showInstructions: false hides instruction footer 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [32m●[39m opt0
+[36m│[39m  [2m○[22m [2mopt1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mopt0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`select (isCI = false) > up arrow selects previous option 1`] = `
 [
   "<cursor.hide>",
@@ -1051,6 +1071,26 @@ exports[`select (isCI = true) > renders options and message 1`] = `
 [36m└[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2mopt0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`select (isCI = true) > showInstructions: false hides instruction footer 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [32m●[39m opt0
+[36m│[39m  [2m○[22m [2mopt1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=1>",
   "<erase.down>",
   "[32m◇[39m  foo

--- a/packages/prompts/test/group-multi-select.test.ts
+++ b/packages/prompts/test/group-multi-select.test.ts
@@ -481,4 +481,22 @@ describe.each(['true', 'false'])('groupMultiselect (isCI = %s)', (isCI) => {
 		expect(value).toEqual(['group1value0']);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('showInstructions: false hides instruction footer', async () => {
+		const result = prompts.groupMultiselect({
+			message: 'foo',
+			input,
+			output,
+			showInstructions: false,
+			required: false,
+			options: {
+				group1: [{ value: 'group1value0' }, { value: 'group1value1' }],
+			},
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+
+		await result;
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/multi-select.test.ts
+++ b/packages/prompts/test/multi-select.test.ts
@@ -476,4 +476,20 @@ describe.each(['true', 'false'])('multiselect (isCI = %s)', (isCI) => {
 		expect(value).toEqual(['opt6']);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('showInstructions: false hides instruction footer', async () => {
+		const result = prompts.multiselect({
+			message: 'foo',
+			options: [{ value: 'opt0' }, { value: 'opt1' }],
+			showInstructions: false,
+			required: false,
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+
+		await result;
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/select.test.ts
+++ b/packages/prompts/test/select.test.ts
@@ -377,6 +377,21 @@ describe.each(['true', 'false'])('select (isCI = %s)', (isCI) => {
 		expect(output.buffer).toMatchSnapshot();
 	});
 
+	test('showInstructions: false hides instruction footer', async () => {
+		const result = prompts.select({
+			message: 'foo',
+			options: [{ value: 'opt0' }, { value: 'opt1' }],
+			showInstructions: false,
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+
+		await result;
+		expect(output.buffer).toMatchSnapshot();
+	});
+
 	test('correctly limits options with explicit multiline message', async () => {
 		output.rows = 12;
 


### PR DESCRIPTION
## What does this PR do?

<!--
  Describe the change and why it's needed. Link to a related issue or discussion.
  If there is no issue, please explain why one isn't needed.
-->

adds `showInstructions` opt-out to `select`, `multiselect` and `group-multiselect` prompts

Closes #571

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
