### PR TITLE
fix(prompts): calculate multi-select vertical offsets using post-wrapped line counts

### DIFF
--- a/.changeset/multiselect-overflow-fix.md
+++ b/.changeset/multiselect-overflow-fix.md
@@ -1,0 +1,5 @@
+---
+'@clack/prompts': patch
+---
+
+fix: correctly calculate multiselect layout row padding on narrow terminals to prevent option text overflow and visual overwriting

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -170,8 +170,9 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 						)
 						.join('\n');
 					// Calculate rowPadding: title lines + footer lines (error message + trailing newline)
-					const titleLineCount = title.split('\n').length;
-					const footerLineCount = footer.split('\n').length + 1; // footer + trailing newline
+					const titleLineCount = title.split('\n').length - 1;
+					const wrappedFooter = wrapTextWithPrefix(opts.output, footer, '');
+					const footerLineCount = wrappedFooter.split('\n').length + 1; // footer + trailing newline
 					return `${title}${prefix}${limitOptions({
 						output: opts.output,
 						options: this.options,
@@ -184,14 +185,15 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 				}
 				default: {
 					const prefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : '';
-					const titleLineCount = title.split('\n').length;
+					const titleLineCount = title.split('\n').length - 1;
 					const footerLines = showInstructions
 						? formatInstructionFooter(MULTISELECT_INSTRUCTIONS, hasGuide)
 						: hasGuide
 							? [styleText('cyan', S_BAR_END)]
 							: [];
 					const footerText = footerLines.join('\n');
-					const footerLineCount = footerLines.length + 1;
+					const wrappedFooter = wrapTextWithPrefix(opts.output, footerText, '');
+					const footerLineCount = wrappedFooter.split('\n').length + 1;
 					return `${title}${prefix}${limitOptions({
 						output: opts.output,
 						options: this.options,

--- a/packages/prompts/test/__snapshots__/multi-select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/multi-select.test.ts.snap
@@ -1,14 +1,47 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`multiselect (isCI = false) > calculates rowPadding properly on narrow terminals with wrapped footers 1`] = `
+[
+  "<cursor.hide>",
+  "[90m|[39m
+[36m*[39m  Select an option
+[36m|[39m  [36m[•][39m Option 0
+[36m|[39m  [2m[ ][22m [2mOption 1[22m
+[36m|[39m  [2m[ ][22m [2mOption 2[22m
+[36m|[39m  [2m[ ][22m [2mOption 3[22m
+[36m|[39m  [2m[ ][22m [2mOption 4[22m
+[36m|[39m  [2m[ ][22m [2mOption 5[22m
+[36m|[39m  [2m[ ][22m [2mOption 6[22m
+[36m|[39m  [2m[ ][22m [2mOption 7[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
+",
+  "<cursor.backward count=999><cursor.up count=13>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m|[39m  [32m[+][39m Option 0",
+  "<cursor.down count=11>",
+  "<cursor.backward count=999><cursor.up count=13>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32mo[39m  Select an option
+[90m|[39m  [2mOption 0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`multiselect (isCI = false) > can be aborted by a signal 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "
 ",
@@ -19,18 +52,18 @@ exports[`multiselect (isCI = false) > can be aborted by a signal 1`] = `
 exports[`multiselect (isCI = false) > can cancel 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[31m■[39m  foo
-[90m│[39m",
+  "[31mx[39m  foo
+[90m|[39m",
   "
 ",
   "<cursor.show>",
@@ -40,23 +73,23 @@ exports[`multiselect (isCI = false) > can cancel 1`] = `
 exports[`multiselect (isCI = false) > can render option hints 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0 [2m(Hint 0)[22m
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0 [2m(Hint 0)[22m
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0 [2m(Hint 0)[22m",
+  "[36m|[39m  [32m[+][39m opt0 [2m(Hint 0)[22m",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -66,23 +99,23 @@ exports[`multiselect (isCI = false) > can render option hints 1`] = `
 exports[`multiselect (isCI = false) > can set cursorAt to preselect an option 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [2m◻[22m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [2m[ ][22m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=3>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt1",
+  "[36m|[39m  [32m[+][39m opt1",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -92,23 +125,23 @@ exports[`multiselect (isCI = false) > can set cursorAt to preselect an option 1`
 exports[`multiselect (isCI = false) > can set custom labels 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m Option 0
-[36m│[39m  [2m◻[22m [2mOption 1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m Option 0
+[36m|[39m  [2m[ ][22m [2mOption 1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m Option 0",
+  "[36m|[39m  [32m[+][39m Option 0",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mOption 0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mOption 0[22m",
   "
 ",
   "<cursor.show>",
@@ -118,18 +151,18 @@ exports[`multiselect (isCI = false) > can set custom labels 1`] = `
 exports[`multiselect (isCI = false) > can set initial values 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [32m◼[39m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [32m[+][39m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -139,18 +172,18 @@ exports[`multiselect (isCI = false) > can set initial values 1`] = `
 exports[`multiselect (isCI = false) > can submit without selection when required = false 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mnone[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mnone[22m",
   "
 ",
   "<cursor.show>",
@@ -160,19 +193,19 @@ exports[`multiselect (isCI = false) > can submit without selection when required
 exports[`multiselect (isCI = false) > global withGuide: false removes guide 1`] = `
 [
   "<cursor.hide>",
-  "[36m◆[39m  foo
-[36m◻[39m opt0
-[2m◻[22m [2mopt1[22m
+  "[36m*[39m  foo
+[36m[•][39m opt0
+[2m[ ][22m [2mopt1[22m
 [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
 ",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.line><cursor.left count=1>",
-  "[32m◼[39m opt0",
+  "[32m[+][39m opt0",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<erase.down>",
-  "[32m◇[39m  foo
+  "[32mo[39m  foo
 [2mopt0[22m",
   "
 ",
@@ -183,94 +216,94 @@ exports[`multiselect (isCI = false) > global withGuide: false removes guide 1`] 
 exports[`multiselect (isCI = false) > maxItems accounts for instruction footer 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [36m◻[39m opt2
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [36m[•][39m opt2
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [36m◻[39m opt3
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [36m[•][39m opt3
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m...[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [36m◻[39m opt4
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m...[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [36m[•][39m opt4
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [36m◻[39m opt5
-[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [36m[•][39m opt5
+[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [36m◻[39m opt6
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [36m[•][39m opt6
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=5>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt6",
+  "[36m|[39m  [32m[+][39m opt6",
   "<cursor.down count=5>",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt6[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt6[22m",
   "
 ",
   "<cursor.show>",
@@ -280,94 +313,94 @@ exports[`multiselect (isCI = false) > maxItems accounts for instruction footer 1
 exports[`multiselect (isCI = false) > maxItems renders a sliding window 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [36m◻[39m opt2
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [36m[•][39m opt2
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [36m◻[39m opt3
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [36m[•][39m opt3
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m...[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [36m◻[39m opt4
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m...[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [36m[•][39m opt4
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [36m◻[39m opt5
-[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [36m[•][39m opt5
+[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [36m◻[39m opt6
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [36m[•][39m opt6
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=5>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt6",
+  "[36m|[39m  [32m[+][39m opt6",
   "<cursor.down count=5>",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt6[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt6[22m",
   "
 ",
   "<cursor.show>",
@@ -377,24 +410,24 @@ exports[`multiselect (isCI = false) > maxItems renders a sliding window 1`] = `
 exports[`multiselect (isCI = false) > renders disabled options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [90m◻[39m [9m[90mopt0[39m[29m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [90m◻[39m [9m[90mopt2[39m[29m [2m(Hint 2)[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [90m[ ][39m [9m[90mopt0[39m[29m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [90m[ ][39m [9m[90mopt2[39m[29m [2m(Hint 2)[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt1",
+  "[36m|[39m  [32m[+][39m opt1",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -404,14 +437,14 @@ exports[`multiselect (isCI = false) > renders disabled options 1`] = `
 exports[`multiselect (isCI = false) > renders instructions without guide 1`] = `
 [
   "<cursor.hide>",
-  "[36m◆[39m  foo
-[36m◻[39m opt0
-[2m◻[22m [2mopt1[22m
+  "[36m*[39m  foo
+[36m[•][39m opt0
+[2m[ ][22m [2mopt1[22m
 [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
 ",
   "<cursor.backward count=999><cursor.up count=4>",
   "<erase.down>",
-  "[32m◇[39m  foo
+  "[32mo[39m  foo
 [2mnone[22m",
   "
 ",
@@ -422,23 +455,23 @@ exports[`multiselect (isCI = false) > renders instructions without guide 1`] = `
 exports[`multiselect (isCI = false) > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -448,39 +481,39 @@ exports[`multiselect (isCI = false) > renders message 1`] = `
 exports[`multiselect (isCI = false) > renders multiple cancelled values 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=5>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt1",
+  "[36m|[39m  [32m[+][39m opt1",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[31m■[39m  foo
-[90m│[39m  [9m[2mopt0[22m[29m[2m, [22m[9m[2mopt1[22m[29m
-[90m│[39m",
+  "[31mx[39m  foo
+[90m|[39m  [9m[2mopt0[22m[29m[2m, [22m[9m[2mopt1[22m[29m
+[90m|[39m",
   "
 ",
   "<cursor.show>",
@@ -490,46 +523,46 @@ exports[`multiselect (isCI = false) > renders multiple cancelled values 1`] = `
 exports[`multiselect (isCI = false) > renders multiple selected options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=5>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt1",
+  "[36m|[39m  [32m[+][39m opt1",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt1[22m
-[36m│[39m  [36m◻[39m opt2
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt1[22m
+[36m|[39m  [36m[•][39m opt2
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m[2m, [22m[2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m[2m, [22m[2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -539,36 +572,36 @@ exports[`multiselect (isCI = false) > renders multiple selected options 1`] = `
 exports[`multiselect (isCI = false) > renders validation errors 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[33m▲[39m  foo
-[33m│[39m  [36m◻[39m opt0
-[33m│[39m  [2m◻[22m [2mopt1[22m
-[33m└[39m  [33mPlease select at least one option.[39m
+  "[33mx[39m  foo
+[33m|[39m  [36m[•][39m opt0
+[33m|[39m  [2m[ ][22m [2mopt1[22m
+[33m—[39m  [33mPlease select at least one option.[39m
    [0m[2mPress [90m[47m[7m space [27m[49m[39m to select, [90m[47m[7m enter [27m[49m[39m to submit[22m[0m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  [32m◼[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m*[39m  foo
+[36m|[39m  [32m[+][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -578,17 +611,17 @@ exports[`multiselect (isCI = false) > renders validation errors 1`] = `
 exports[`multiselect (isCI = false) > showInstructions: false hides instruction footer 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mnone[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mnone[22m",
   "
 ",
   "<cursor.show>",
@@ -598,36 +631,36 @@ exports[`multiselect (isCI = false) > showInstructions: false hides instruction 
 exports[`multiselect (isCI = false) > shows hints for all selected options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [32m◼[39m opt0 [2m(Hint 0)[22m
-[36m│[39m  [32m◼[39m [2mopt1[22m [2m(Hint 1)[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [32m[+][39m opt0 [2m(Hint 0)[22m
+[36m|[39m  [32m[+][39m [2mopt1[22m [2m(Hint 1)[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt0[22m [2m(Hint 0)[22m
-[36m│[39m  [32m◼[39m opt1 [2m(Hint 1)[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt0[22m [2m(Hint 0)[22m
+[36m|[39m  [32m[+][39m opt1 [2m(Hint 1)[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt1[22m [2m(Hint 1)[22m
-[36m│[39m  [36m◻[39m opt2 [2m(Hint 2)[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt1[22m [2m(Hint 1)[22m
+[36m|[39m  [36m[•][39m opt2 [2m(Hint 2)[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m[2m, [22m[2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m[2m, [22m[2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -637,156 +670,156 @@ exports[`multiselect (isCI = false) > shows hints for all selected options 1`] =
 exports[`multiselect (isCI = false) > sliding window loops downwards 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [36m◻[39m opt2
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [36m[•][39m opt2
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [36m◻[39m opt3
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [36m[•][39m opt3
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m...[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [36m◻[39m opt4
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m...[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [36m[•][39m opt4
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [36m◻[39m opt5
-[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [36m[•][39m opt5
+[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [36m◻[39m opt6
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [36m[•][39m opt6
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [36m◻[39m opt7
-[36m│[39m  [2m◻[22m [2mopt8[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [36m[•][39m opt7
+[36m|[39m  [2m[ ][22m [2mopt8[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [36m◻[39m opt8
-[36m│[39m  [2m◻[22m [2mopt9[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [36m[•][39m opt8
+[36m|[39m  [2m[ ][22m [2mopt9[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m◻[22m [2mopt8[22m
-[36m│[39m  [36m◻[39m opt9
-[36m│[39m  [2m◻[22m [2mopt10[22m
-[36m│[39m  [2m◻[22m [2mopt11[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m[ ][22m [2mopt8[22m
+[36m|[39m  [36m[•][39m opt9
+[36m|[39m  [2m[ ][22m [2mopt10[22m
+[36m|[39m  [2m[ ][22m [2mopt11[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=5>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt9[22m
-[36m│[39m  [36m◻[39m opt10
-[36m│[39m  [2m◻[22m [2mopt11[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt9[22m
+[36m|[39m  [36m[•][39m opt10
+[36m|[39m  [2m[ ][22m [2mopt11[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=6>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt10[22m
-[36m│[39m  [36m◻[39m opt11
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt10[22m
+[36m|[39m  [36m[•][39m opt11
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=8>",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -796,39 +829,39 @@ exports[`multiselect (isCI = false) > sliding window loops downwards 1`] = `
 exports[`multiselect (isCI = false) > sliding window loops upwards 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m...[22m
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m◻[22m [2mopt8[22m
-[36m│[39m  [2m◻[22m [2mopt9[22m
-[36m│[39m  [2m◻[22m [2mopt10[22m
-[36m│[39m  [36m◻[39m opt11
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m...[22m
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m[ ][22m [2mopt8[22m
+[36m|[39m  [2m[ ][22m [2mopt9[22m
+[36m|[39m  [2m[ ][22m [2mopt10[22m
+[36m|[39m  [36m[•][39m opt11
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=7>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt11",
+  "[36m|[39m  [32m[+][39m opt11",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt11[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt11[22m",
   "
 ",
   "<cursor.show>",
@@ -838,19 +871,19 @@ exports[`multiselect (isCI = false) > sliding window loops upwards 1`] = `
 exports[`multiselect (isCI = false) > withGuide: false removes guide 1`] = `
 [
   "<cursor.hide>",
-  "[36m◆[39m  foo
-[36m◻[39m opt0
-[2m◻[22m [2mopt1[22m
+  "[36m*[39m  foo
+[36m[•][39m opt0
+[2m[ ][22m [2mopt1[22m
 [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
 ",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.line><cursor.left count=1>",
-  "[32m◼[39m opt0",
+  "[32m[+][39m opt0",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<erase.down>",
-  "[32m◇[39m  foo
+  "[32mo[39m  foo
 [2mopt0[22m",
   "
 ",
@@ -861,33 +894,33 @@ exports[`multiselect (isCI = false) > withGuide: false removes guide 1`] = `
 exports[`multiselect (isCI = false) > wraps cancelled state with long options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m Option 0 Option 0 Option 
-[36m│[39m  0 Option 0 Option 0 Option 
-[36m│[39m  0 Option 0 Option 0 Option 
-[36m│[39m  0 Option 0
-[36m│[39m  [2m◻[22m [2mOption 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m Option 0 Option 0 
+[36m|[39m  Option 0 Option 0 Option 0 
+[36m|[39m  Option 0 Option 0 Option 0 
+[36m|[39m  Option 0 Option 0
+[36m|[39m  [2m[ ][22m [2mOption 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=12>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m Option 0 Option 0 Option ",
+  "[36m|[39m  [32m[+][39m Option 0 Option 0 ",
   "<cursor.down count=10>",
   "<cursor.backward count=999><cursor.up count=12>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[31m■[39m  foo
-[90m│[39m  [9m[2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0[22m[29m
-[90m│[39m",
+  "[31mx[39m  foo
+[90m|[39m  [9m[2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0[22m[29m
+[90m|[39m",
   "
 ",
   "<cursor.show>",
@@ -897,27 +930,27 @@ exports[`multiselect (isCI = false) > wraps cancelled state with long options 1`
 exports[`multiselect (isCI = false) > wraps long messages 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo foo foo foo foo foo foo
-[36m│[39m   foo foo foo foo foo foo 
-[36m│[39m  foo foo foo foo foo foo foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo foo foo foo foo foo foo
+[36m|[39m   foo foo foo foo foo foo 
+[36m|[39m  foo foo foo foo foo foo foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=8>",
   "<cursor.down count=4>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=8>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo foo foo foo foo foo foo
-[32m│[39m   foo foo foo foo foo foo 
-[32m│[39m  foo foo foo foo foo foo foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo foo foo foo foo foo foo
+[32m|[39m   foo foo foo foo foo foo 
+[32m|[39m  foo foo foo foo foo foo foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -927,32 +960,65 @@ exports[`multiselect (isCI = false) > wraps long messages 1`] = `
 exports[`multiselect (isCI = false) > wraps success state with long options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m Option 0 Option 0 Option 
-[36m│[39m  0 Option 0 Option 0 Option 
-[36m│[39m  0 Option 0 Option 0 Option 
-[36m│[39m  0 Option 0
-[36m│[39m  [2m◻[22m [2mOption 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m Option 0 Option 0 
+[36m|[39m  Option 0 Option 0 Option 0 
+[36m|[39m  Option 0 Option 0 Option 0 
+[36m|[39m  Option 0 Option 0
+[36m|[39m  [2m[ ][22m [2mOption 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=12>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m Option 0 Option 0 Option ",
+  "[36m|[39m  [32m[+][39m Option 0 Option 0 ",
   "<cursor.down count=10>",
   "<cursor.backward count=999><cursor.up count=12>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`multiselect (isCI = true) > calculates rowPadding properly on narrow terminals with wrapped footers 1`] = `
+[
+  "<cursor.hide>",
+  "[90m|[39m
+[36m*[39m  Select an option
+[36m|[39m  [36m[•][39m Option 0
+[36m|[39m  [2m[ ][22m [2mOption 1[22m
+[36m|[39m  [2m[ ][22m [2mOption 2[22m
+[36m|[39m  [2m[ ][22m [2mOption 3[22m
+[36m|[39m  [2m[ ][22m [2mOption 4[22m
+[36m|[39m  [2m[ ][22m [2mOption 5[22m
+[36m|[39m  [2m[ ][22m [2mOption 6[22m
+[36m|[39m  [2m[ ][22m [2mOption 7[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
+",
+  "<cursor.backward count=999><cursor.up count=13>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m|[39m  [32m[+][39m Option 0",
+  "<cursor.down count=11>",
+  "<cursor.backward count=999><cursor.up count=13>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32mo[39m  Select an option
+[90m|[39m  [2mOption 0[22m",
   "
 ",
   "<cursor.show>",
@@ -962,12 +1028,12 @@ exports[`multiselect (isCI = false) > wraps success state with long options 1`] 
 exports[`multiselect (isCI = true) > can be aborted by a signal 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "
 ",
@@ -978,18 +1044,18 @@ exports[`multiselect (isCI = true) > can be aborted by a signal 1`] = `
 exports[`multiselect (isCI = true) > can cancel 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[31m■[39m  foo
-[90m│[39m",
+  "[31mx[39m  foo
+[90m|[39m",
   "
 ",
   "<cursor.show>",
@@ -999,23 +1065,23 @@ exports[`multiselect (isCI = true) > can cancel 1`] = `
 exports[`multiselect (isCI = true) > can render option hints 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0 [2m(Hint 0)[22m
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0 [2m(Hint 0)[22m
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0 [2m(Hint 0)[22m",
+  "[36m|[39m  [32m[+][39m opt0 [2m(Hint 0)[22m",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -1025,23 +1091,23 @@ exports[`multiselect (isCI = true) > can render option hints 1`] = `
 exports[`multiselect (isCI = true) > can set cursorAt to preselect an option 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [2m◻[22m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [2m[ ][22m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=3>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt1",
+  "[36m|[39m  [32m[+][39m opt1",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -1051,23 +1117,23 @@ exports[`multiselect (isCI = true) > can set cursorAt to preselect an option 1`]
 exports[`multiselect (isCI = true) > can set custom labels 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m Option 0
-[36m│[39m  [2m◻[22m [2mOption 1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m Option 0
+[36m|[39m  [2m[ ][22m [2mOption 1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m Option 0",
+  "[36m|[39m  [32m[+][39m Option 0",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mOption 0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mOption 0[22m",
   "
 ",
   "<cursor.show>",
@@ -1077,18 +1143,18 @@ exports[`multiselect (isCI = true) > can set custom labels 1`] = `
 exports[`multiselect (isCI = true) > can set initial values 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [32m◼[39m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [32m[+][39m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -1098,18 +1164,18 @@ exports[`multiselect (isCI = true) > can set initial values 1`] = `
 exports[`multiselect (isCI = true) > can submit without selection when required = false 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mnone[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mnone[22m",
   "
 ",
   "<cursor.show>",
@@ -1119,19 +1185,19 @@ exports[`multiselect (isCI = true) > can submit without selection when required 
 exports[`multiselect (isCI = true) > global withGuide: false removes guide 1`] = `
 [
   "<cursor.hide>",
-  "[36m◆[39m  foo
-[36m◻[39m opt0
-[2m◻[22m [2mopt1[22m
+  "[36m*[39m  foo
+[36m[•][39m opt0
+[2m[ ][22m [2mopt1[22m
 [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
 ",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.line><cursor.left count=1>",
-  "[32m◼[39m opt0",
+  "[32m[+][39m opt0",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<erase.down>",
-  "[32m◇[39m  foo
+  "[32mo[39m  foo
 [2mopt0[22m",
   "
 ",
@@ -1142,94 +1208,94 @@ exports[`multiselect (isCI = true) > global withGuide: false removes guide 1`] =
 exports[`multiselect (isCI = true) > maxItems accounts for instruction footer 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [36m◻[39m opt2
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [36m[•][39m opt2
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [36m◻[39m opt3
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [36m[•][39m opt3
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m...[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [36m◻[39m opt4
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m...[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [36m[•][39m opt4
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [36m◻[39m opt5
-[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [36m[•][39m opt5
+[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [36m◻[39m opt6
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [36m[•][39m opt6
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=5>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt6",
+  "[36m|[39m  [32m[+][39m opt6",
   "<cursor.down count=5>",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt6[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt6[22m",
   "
 ",
   "<cursor.show>",
@@ -1239,94 +1305,94 @@ exports[`multiselect (isCI = true) > maxItems accounts for instruction footer 1`
 exports[`multiselect (isCI = true) > maxItems renders a sliding window 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [36m◻[39m opt2
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [36m[•][39m opt2
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [36m◻[39m opt3
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [36m[•][39m opt3
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m...[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [36m◻[39m opt4
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m...[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [36m[•][39m opt4
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [36m◻[39m opt5
-[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [36m[•][39m opt5
+[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [36m◻[39m opt6
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [36m[•][39m opt6
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=5>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt6",
+  "[36m|[39m  [32m[+][39m opt6",
   "<cursor.down count=5>",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt6[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt6[22m",
   "
 ",
   "<cursor.show>",
@@ -1336,24 +1402,24 @@ exports[`multiselect (isCI = true) > maxItems renders a sliding window 1`] = `
 exports[`multiselect (isCI = true) > renders disabled options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [90m◻[39m [9m[90mopt0[39m[29m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [90m◻[39m [9m[90mopt2[39m[29m [2m(Hint 2)[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [90m[ ][39m [9m[90mopt0[39m[29m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [90m[ ][39m [9m[90mopt2[39m[29m [2m(Hint 2)[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt1",
+  "[36m|[39m  [32m[+][39m opt1",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -1363,14 +1429,14 @@ exports[`multiselect (isCI = true) > renders disabled options 1`] = `
 exports[`multiselect (isCI = true) > renders instructions without guide 1`] = `
 [
   "<cursor.hide>",
-  "[36m◆[39m  foo
-[36m◻[39m opt0
-[2m◻[22m [2mopt1[22m
+  "[36m*[39m  foo
+[36m[•][39m opt0
+[2m[ ][22m [2mopt1[22m
 [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
 ",
   "<cursor.backward count=999><cursor.up count=4>",
   "<erase.down>",
-  "[32m◇[39m  foo
+  "[32mo[39m  foo
 [2mnone[22m",
   "
 ",
@@ -1381,23 +1447,23 @@ exports[`multiselect (isCI = true) > renders instructions without guide 1`] = `
 exports[`multiselect (isCI = true) > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -1407,39 +1473,39 @@ exports[`multiselect (isCI = true) > renders message 1`] = `
 exports[`multiselect (isCI = true) > renders multiple cancelled values 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=5>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt1",
+  "[36m|[39m  [32m[+][39m opt1",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[31m■[39m  foo
-[90m│[39m  [9m[2mopt0[22m[29m[2m, [22m[9m[2mopt1[22m[29m
-[90m│[39m",
+  "[31mx[39m  foo
+[90m|[39m  [9m[2mopt0[22m[29m[2m, [22m[9m[2mopt1[22m[29m
+[90m|[39m",
   "
 ",
   "<cursor.show>",
@@ -1449,46 +1515,46 @@ exports[`multiselect (isCI = true) > renders multiple cancelled values 1`] = `
 exports[`multiselect (isCI = true) > renders multiple selected options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=5>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt1",
+  "[36m|[39m  [32m[+][39m opt1",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt1[22m
-[36m│[39m  [36m◻[39m opt2
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt1[22m
+[36m|[39m  [36m[•][39m opt2
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m[2m, [22m[2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m[2m, [22m[2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -1498,36 +1564,36 @@ exports[`multiselect (isCI = true) > renders multiple selected options 1`] = `
 exports[`multiselect (isCI = true) > renders validation errors 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[33m▲[39m  foo
-[33m│[39m  [36m◻[39m opt0
-[33m│[39m  [2m◻[22m [2mopt1[22m
-[33m└[39m  [33mPlease select at least one option.[39m
+  "[33mx[39m  foo
+[33m|[39m  [36m[•][39m opt0
+[33m|[39m  [2m[ ][22m [2mopt1[22m
+[33m—[39m  [33mPlease select at least one option.[39m
    [0m[2mPress [90m[47m[7m space [27m[49m[39m to select, [90m[47m[7m enter [27m[49m[39m to submit[22m[0m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  [32m◼[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m*[39m  foo
+[36m|[39m  [32m[+][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -1537,17 +1603,17 @@ exports[`multiselect (isCI = true) > renders validation errors 1`] = `
 exports[`multiselect (isCI = true) > showInstructions: false hides instruction footer 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=5>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mnone[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mnone[22m",
   "
 ",
   "<cursor.show>",
@@ -1557,36 +1623,36 @@ exports[`multiselect (isCI = true) > showInstructions: false hides instruction f
 exports[`multiselect (isCI = true) > shows hints for all selected options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [32m◼[39m opt0 [2m(Hint 0)[22m
-[36m│[39m  [32m◼[39m [2mopt1[22m [2m(Hint 1)[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [32m[+][39m opt0 [2m(Hint 0)[22m
+[36m|[39m  [32m[+][39m [2mopt1[22m [2m(Hint 1)[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt0[22m [2m(Hint 0)[22m
-[36m│[39m  [32m◼[39m opt1 [2m(Hint 1)[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt0[22m [2m(Hint 0)[22m
+[36m|[39m  [32m[+][39m opt1 [2m(Hint 1)[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [32m◼[39m [2mopt1[22m [2m(Hint 1)[22m
-[36m│[39m  [36m◻[39m opt2 [2m(Hint 2)[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [32m[+][39m [2mopt1[22m [2m(Hint 1)[22m
+[36m|[39m  [36m[•][39m opt2 [2m(Hint 2)[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m[2m, [22m[2mopt1[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m[2m, [22m[2mopt1[22m",
   "
 ",
   "<cursor.show>",
@@ -1596,156 +1662,156 @@ exports[`multiselect (isCI = true) > shows hints for all selected options 1`] = 
 exports[`multiselect (isCI = true) > sliding window loops downwards 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt0[22m
-[36m│[39m  [36m◻[39m opt1
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt0[22m
+[36m|[39m  [36m[•][39m opt1
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [36m◻[39m opt2
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [36m[•][39m opt2
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [36m◻[39m opt3
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [36m[•][39m opt3
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m...[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [36m◻[39m opt4
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m...[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [36m[•][39m opt4
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [36m◻[39m opt5
-[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [36m[•][39m opt5
+[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [36m◻[39m opt6
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [36m[•][39m opt6
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt5[22m
-[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [36m◻[39m opt7
-[36m│[39m  [2m◻[22m [2mopt8[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt5[22m
+[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [36m[•][39m opt7
+[36m|[39m  [2m[ ][22m [2mopt8[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt6[22m
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [36m◻[39m opt8
-[36m│[39m  [2m◻[22m [2mopt9[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt6[22m
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [36m[•][39m opt8
+[36m|[39m  [2m[ ][22m [2mopt9[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m◻[22m [2mopt8[22m
-[36m│[39m  [36m◻[39m opt9
-[36m│[39m  [2m◻[22m [2mopt10[22m
-[36m│[39m  [2m◻[22m [2mopt11[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m[ ][22m [2mopt8[22m
+[36m|[39m  [36m[•][39m opt9
+[36m|[39m  [2m[ ][22m [2mopt10[22m
+[36m|[39m  [2m[ ][22m [2mopt11[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=5>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt9[22m
-[36m│[39m  [36m◻[39m opt10
-[36m│[39m  [2m◻[22m [2mopt11[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt9[22m
+[36m|[39m  [36m[•][39m opt10
+[36m|[39m  [2m[ ][22m [2mopt11[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=6>",
   "<erase.down>",
-  "[36m│[39m  [2m◻[22m [2mopt10[22m
-[36m│[39m  [36m◻[39m opt11
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m[ ][22m [2mopt10[22m
+[36m|[39m  [36m[•][39m opt11
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=8>",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -1755,39 +1821,39 @@ exports[`multiselect (isCI = true) > sliding window loops downwards 1`] = `
 exports[`multiselect (isCI = true) > sliding window loops upwards 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m◻[22m [2mopt2[22m
-[36m│[39m  [2m◻[22m [2mopt3[22m
-[36m│[39m  [2m◻[22m [2mopt4[22m
-[36m│[39m  [2m...[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m[ ][22m [2mopt2[22m
+[36m|[39m  [2m[ ][22m [2mopt3[22m
+[36m|[39m  [2m[ ][22m [2mopt4[22m
+[36m|[39m  [2m...[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=2>",
   "<erase.down>",
-  "[36m│[39m  [2m...[22m
-[36m│[39m  [2m◻[22m [2mopt7[22m
-[36m│[39m  [2m◻[22m [2mopt8[22m
-[36m│[39m  [2m◻[22m [2mopt9[22m
-[36m│[39m  [2m◻[22m [2mopt10[22m
-[36m│[39m  [36m◻[39m opt11
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[36m|[39m  [2m...[22m
+[36m|[39m  [2m[ ][22m [2mopt7[22m
+[36m|[39m  [2m[ ][22m [2mopt8[22m
+[36m|[39m  [2m[ ][22m [2mopt9[22m
+[36m|[39m  [2m[ ][22m [2mopt10[22m
+[36m|[39m  [36m[•][39m opt11
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=7>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt11",
+  "[36m|[39m  [32m[+][39m opt11",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mopt11[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mopt11[22m",
   "
 ",
   "<cursor.show>",
@@ -1797,19 +1863,19 @@ exports[`multiselect (isCI = true) > sliding window loops upwards 1`] = `
 exports[`multiselect (isCI = true) > withGuide: false removes guide 1`] = `
 [
   "<cursor.hide>",
-  "[36m◆[39m  foo
-[36m◻[39m opt0
-[2m◻[22m [2mopt1[22m
+  "[36m*[39m  foo
+[36m[•][39m opt0
+[2m[ ][22m [2mopt1[22m
 [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
 ",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.line><cursor.left count=1>",
-  "[32m◼[39m opt0",
+  "[32m[+][39m opt0",
   "<cursor.down count=3>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<erase.down>",
-  "[32m◇[39m  foo
+  "[32mo[39m  foo
 [2mopt0[22m",
   "
 ",
@@ -1820,33 +1886,33 @@ exports[`multiselect (isCI = true) > withGuide: false removes guide 1`] = `
 exports[`multiselect (isCI = true) > wraps cancelled state with long options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m Option 0 Option 0 Option 
-[36m│[39m  0 Option 0 Option 0 Option 
-[36m│[39m  0 Option 0 Option 0 Option 
-[36m│[39m  0 Option 0
-[36m│[39m  [2m◻[22m [2mOption 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m Option 0 Option 0 
+[36m|[39m  Option 0 Option 0 Option 0 
+[36m|[39m  Option 0 Option 0 Option 0 
+[36m|[39m  Option 0 Option 0
+[36m|[39m  [2m[ ][22m [2mOption 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=12>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m Option 0 Option 0 Option ",
+  "[36m|[39m  [32m[+][39m Option 0 Option 0 ",
   "<cursor.down count=10>",
   "<cursor.backward count=999><cursor.up count=12>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[31m■[39m  foo
-[90m│[39m  [9m[2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0[22m[29m
-[90m│[39m",
+  "[31mx[39m  foo
+[90m|[39m  [9m[2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0[22m[29m
+[90m|[39m",
   "
 ",
   "<cursor.show>",
@@ -1856,27 +1922,27 @@ exports[`multiselect (isCI = true) > wraps cancelled state with long options 1`]
 exports[`multiselect (isCI = true) > wraps long messages 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo foo foo foo foo foo foo
-[36m│[39m   foo foo foo foo foo foo 
-[36m│[39m  foo foo foo foo foo foo foo
-[36m│[39m  [36m◻[39m opt0
-[36m│[39m  [2m◻[22m [2mopt1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo foo foo foo foo foo foo
+[36m|[39m   foo foo foo foo foo foo 
+[36m|[39m  foo foo foo foo foo foo foo
+[36m|[39m  [36m[•][39m opt0
+[36m|[39m  [2m[ ][22m [2mopt1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=8>",
   "<cursor.down count=4>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m opt0",
+  "[36m|[39m  [32m[+][39m opt0",
   "<cursor.down count=4>",
   "<cursor.backward count=999><cursor.up count=8>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo foo foo foo foo foo foo
-[32m│[39m   foo foo foo foo foo foo 
-[32m│[39m  foo foo foo foo foo foo foo
-[90m│[39m  [2mopt0[22m",
+  "[32mo[39m  foo foo foo foo foo foo foo
+[32m|[39m   foo foo foo foo foo foo 
+[32m|[39m  foo foo foo foo foo foo foo
+[90m|[39m  [2mopt0[22m",
   "
 ",
   "<cursor.show>",
@@ -1886,32 +1952,32 @@ exports[`multiselect (isCI = true) > wraps long messages 1`] = `
 exports[`multiselect (isCI = true) > wraps success state with long options 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
-[36m◆[39m  foo
-[36m│[39m  [36m◻[39m Option 0 Option 0 Option 
-[36m│[39m  0 Option 0 Option 0 Option 
-[36m│[39m  0 Option 0 Option 0 Option 
-[36m│[39m  0 Option 0
-[36m│[39m  [2m◻[22m [2mOption 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1 Option 1 Option [22m
-[36m│[39m  [2m1 Option 1[22m
-[36m│[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
-[36m└[39m
+  "[90m|[39m
+[36m*[39m  foo
+[36m|[39m  [36m[•][39m Option 0 Option 0 
+[36m|[39m  Option 0 Option 0 Option 0 
+[36m|[39m  Option 0 Option 0 Option 0 
+[36m|[39m  Option 0 Option 0
+[36m|[39m  [2m[ ][22m [2mOption 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1 Option 1 [22m
+[36m|[39m  [2mOption 1 Option 1[22m
+[36m|[39m  [2m↑/↓[22m to navigate • [2mSpace:[22m select • [2mEnter:[22m confirm
+[36m—[39m
 ",
   "<cursor.backward count=999><cursor.up count=12>",
   "<cursor.down count=2>",
   "<erase.line><cursor.left count=1>",
-  "[36m│[39m  [32m◼[39m Option 0 Option 0 Option ",
+  "[36m|[39m  [32m[+][39m Option 0 Option 0 ",
   "<cursor.down count=10>",
   "<cursor.backward count=999><cursor.up count=12>",
   "<cursor.down count=1>",
   "<erase.down>",
-  "[32m◇[39m  foo
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0 Option 0 Option 0 [22m
-[90m│[39m  [2mOption 0[22m",
+  "[32mo[39m  foo
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0 Option 0 Option 0 [22m
+[90m|[39m  [2mOption 0[22m",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/multi-select.test.ts
+++ b/packages/prompts/test/multi-select.test.ts
@@ -496,10 +496,13 @@ describe.each(['true', 'false'])('multiselect (isCI = %s)', (isCI) => {
 	test('calculates rowPadding properly on narrow terminals with wrapped footers', async () => {
 		output.columns = 30; // Very narrow terminal
 		output.rows = 15; // Small height
-		
+
 		const result = prompts.multiselect({
 			message: 'Select an option',
-			options: Array.from({ length: 20 }).map((_, i) => ({ value: `opt${i}`, label: `Option ${i}` })),
+			options: Array.from({ length: 20 }).map((_, i) => ({
+				value: `opt${i}`,
+				label: `Option ${i}`,
+			})),
 			input,
 			output,
 		});

--- a/packages/prompts/test/multi-select.test.ts
+++ b/packages/prompts/test/multi-select.test.ts
@@ -492,4 +492,25 @@ describe.each(['true', 'false'])('multiselect (isCI = %s)', (isCI) => {
 		await result;
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('calculates rowPadding properly on narrow terminals with wrapped footers', async () => {
+		output.columns = 30; // Very narrow terminal
+		output.rows = 15; // Small height
+		
+		const result = prompts.multiselect({
+			message: 'Select an option',
+			options: Array.from({ length: 20 }).map((_, i) => ({ value: `opt${i}`, label: `Option ${i}` })),
+			input,
+			output,
+		});
+
+		// Just confirm selection
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'return' });
+
+		await result;
+
+		// The output should be snapshotted correctly without overflowing the rows limit.
+		expect(output.buffer).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
## What does this PR do?

This PR corrects a terminal rendering bug in the `MultiSelectPrompt` where multi-line choices containing wrapped description strings caused terminal cursor line-tracking offsets to miscalculate. By forcing vertical layout boundaries to evaluate height metrics directly from post-wrapped line array lengths rather than raw element counts, the terminal layout accurately positions the cursor and prevents option text from visually overwriting itself on smaller displays.

Closes #116

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new lint or build warnings