### PR TITLE
fix(prompts): truncate wide-character box titles by display width

### DIFF
--- a/.changeset/box-wide-title-truncation.md
+++ b/.changeset/box-wide-title-truncation.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fix `box()` so a title wider than the box is truncated by display width instead of UTF-16 code units. A wide-character (CJK) title that overflowed the title budget previously produced ragged borders, and could throw `RangeError: Invalid count value` once the remainder passed to `'─'.repeat(...)` went negative.

--- a/packages/prompts/src/box.ts
+++ b/packages/prompts/src/box.ts
@@ -96,6 +96,22 @@ function getPaddingForLine(
 	return [leftPadding, rightPadding];
 }
 
+function truncateToWidth(str: string, maxWidth: number): string {
+	const ellipsis = '...';
+	const target = maxWidth - stringWidth(ellipsis);
+	let result = '';
+	let width = 0;
+	for (const char of str) {
+		const charWidth = stringWidth(char);
+		if (width + charWidth > target) {
+			break;
+		}
+		result += char;
+		width += charWidth;
+	}
+	return result + ellipsis;
+}
+
 const defaultFormatBorder = (text: string) => text;
 
 /**
@@ -162,7 +178,7 @@ export const box = (message = '', title = '', opts?: BoxOptions) => {
 	const innerWidth = boxWidth - borderTotalWidth;
 	const maxTitleLength = innerWidth - titlePadding * 2;
 	const truncatedTitle =
-		titleWidth > maxTitleLength ? `${title.slice(0, maxTitleLength - 3)}...` : title;
+		titleWidth > maxTitleLength ? truncateToWidth(title, maxTitleLength) : title;
 	const [titlePaddingLeft, titlePaddingRight] = getPaddingForLine(
 		stringWidth(truncatedTitle),
 		innerWidth,

--- a/packages/prompts/test/box.test.ts
+++ b/packages/prompts/test/box.test.ts
@@ -1,5 +1,6 @@
 import { styleText } from 'node:util';
 import { updateSettings } from '@clack/core';
+import stringWidth from 'fast-string-width';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as prompts from '../src/index.js';
 import { MockReadable, MockWritable } from './test-utils.js';
@@ -269,5 +270,31 @@ describe.each(['true', 'false'])('box (isCI = %s)', (isCI) => {
 		});
 
 		expect(output.buffer).toMatchSnapshot();
+	});
+
+	test('truncates a wide-character title that overflows the box width', () => {
+		// '这是一个非常长的标题' is 10 wide chars = 20 display columns, which
+		// exceeds the title budget at width: 0.2. The title must be truncated by
+		// display width, not by UTF-16 code units, otherwise the trailing
+		// `'─'.repeat(...)` count goes negative and box() throws RangeError.
+		const title = '这是一个非常长的标题';
+		expect(() => {
+			prompts.box('message', title, {
+				input,
+				output,
+				width: 0.2,
+			});
+		}).not.toThrow();
+
+		const rendered = output.buffer.join('');
+		expect(rendered).toContain('...');
+
+		// Every rendered border line must occupy the same number of display
+		// columns; otherwise the box corners are ragged.
+		const lineWidths = rendered
+			.split('\n')
+			.filter((line) => line.length > 0)
+			.map((line) => stringWidth(line));
+		expect(new Set(lineWidths).size).toBe(1);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

`box()` measures the title and every line with `fast-string-width`, but it truncates an over-long title with `title.slice(0, maxTitleLength - 3)`, which counts UTF-16 code units rather than display columns. `maxTitleLength` is a display-width budget, so for a wide-character (CJK/full-width) title the sliced result is still far too wide. The top border comes out ragged, and once `getPaddingForLine` returns a negative remainder, `'─'.repeat(...)` throws `RangeError: Invalid count value`.

Repro on `main`:

```ts
import { box } from '@clack/prompts';

// '这是一个非常长的标题' is 10 full-width chars = 20 display columns
box('message', '这是一个非常长的标题', { width: 0.2 });
// RangeError: Invalid count value: -6
```

The fix replaces the code-unit slice with a small `truncateToWidth` helper that accumulates characters by display width, the same way the rest of `box()` already measures. For ASCII titles it returns exactly what the old slice did, so existing snapshots are unchanged; only wide-character titles change behaviour (they now fit the box and the borders stay aligned).

No linked issue: this is a small self-contained bug fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

- [x] This PR includes AI-generated code
