### PR TITLE
fix: run spinner onCancel on Ctrl+C

### DIFF
--- a/.changeset/swift-spinners-cancel.md
+++ b/.changeset/swift-spinners-cancel.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Run spinner `onCancel` handlers when <kbd>Ctrl</kbd>+<kbd>C</kbd> cancels through blocked input.

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -55,17 +55,18 @@ export const spinner = ({
 	let _prevMessage: string | undefined;
 	let _origin: number = performance.now();
 	const columns = getColumns(output);
+	const input = opts.input ?? process.stdin;
 	const styleFn = opts?.styleFrame ?? defaultStyleFn;
 
 	const handleExit = (code: number) => {
-		const msg =
-			code > 1
-				? (errorMessage ?? settings.messages.error)
-				: (cancelMessage ?? settings.messages.cancel);
-		isCancelled = code === 1;
+		const cancelled = code <= 1;
+		const msg = cancelled
+			? (cancelMessage ?? settings.messages.cancel)
+			: (errorMessage ?? settings.messages.error);
+		isCancelled = cancelled;
 		if (isSpinnerActive) {
-			_stop(msg, code);
-			if (isCancelled && typeof onCancel === 'function') {
+			_stop(msg, cancelled ? 1 : code);
+			if (cancelled && typeof onCancel === 'function') {
 				onCancel();
 			}
 		}
@@ -131,7 +132,7 @@ export const spinner = ({
 
 	const start = (msg = ''): void => {
 		isSpinnerActive = true;
-		unblock = block({ output });
+		unblock = block({ input, output });
 		_message = removeTrailingDots(msg);
 		_origin = performance.now();
 		if (hasGuide) {

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -3,7 +3,7 @@ import { styleText } from 'node:util';
 import { getColumns, updateSettings } from '@clack/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as prompts from '../src/index.js';
-import { MockWritable } from './test-utils.js';
+import { MockReadable, MockWritable } from './test-utils.js';
 
 describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 	let originalCI: string | undefined;
@@ -303,6 +303,23 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			processEmitter.emit('SIGINT');
 
 			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('runs onCancel when Ctrl+C exits through blocked input', () => {
+			const input = new MockReadable();
+			const onCancel = vi.fn();
+			const result = prompts.spinner({ input, output, onCancel });
+			const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code) => {
+				processEmitter.emit('exit', typeof code === 'number' ? code : 0);
+				return undefined as never;
+			}) as typeof process.exit);
+
+			result.start('Test operation');
+			input.emit('keypress', Buffer.from('\x03'), { name: 'c' });
+
+			expect(exitSpy).toHaveBeenCalled();
+			expect(onCancel).toHaveBeenCalledOnce();
+			expect(result.isCancelled).toBe(true);
 		});
 
 		test('uses custom cancel message when provided directly', () => {


### PR DESCRIPTION
## What does this PR do?

Fixes spinner cancellation from <kbd>Ctrl</kbd>+<kbd>C</kbd> when the keypress is handled by the blocked input path. The spinner now treats the blocked-input exit path as cancellation, passes the configured input stream to `block()`, runs `onCancel`, and sets `isCancelled`.

Closes #573

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

- [x] This PR includes AI-generated code
