### PR TITLE
fix: wrap and indent `spinner` messages

### DIFF
--- a/.changeset/shy-wolves-start.md
+++ b/.changeset/shy-wolves-start.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fix `spinner`, `progress` and `task` not wrapping or prefixing newlines in their messages.

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -1,5 +1,5 @@
 import { styleText } from 'node:util';
-import { block, getColumns, settings } from '@clack/core';
+import { block, getColumns, settings, wrapTextWithPrefix } from '@clack/core';
 import { wrapAnsi } from 'fast-wrap-ansi';
 import { cursor, erase } from 'sisteransi';
 import {
@@ -127,15 +127,16 @@ export const spinner = ({
 		return min > 0 ? `[${min}m ${secs}s]` : `[${secs}s]`;
 	};
 
+	const prefix = `${styleText('gray', S_BAR)}  `;
 	const hasGuide = opts.withGuide ?? settings.withGuide;
 
 	const start = (msg = ''): void => {
 		isSpinnerActive = true;
 		unblock = block({ output });
-		_message = removeTrailingDots(msg);
+		_message = wrapTextWithPrefix(output, removeTrailingDots(msg), hasGuide ? prefix : '', '');
 		_origin = performance.now();
 		if (hasGuide) {
-			output.write(`${styleText('gray', S_BAR)}\n`);
+			output.write(`${prefix}\n`);
 		}
 		let frameIndex = 0;
 		let indicatorTimer = 0;
@@ -159,11 +160,7 @@ export const spinner = ({
 				outputMessage = `${frame}  ${_message}${loadingDots}`;
 			}
 
-			const wrapped = wrapAnsi(outputMessage, columns, {
-				hard: true,
-				trim: false,
-			});
-			output.write(wrapped);
+			output.write(outputMessage);
 
 			frameIndex = frameIndex + 1 < frames.length ? frameIndex + 1 : 0;
 			// indicator increase by 1 every 8 frames
@@ -182,7 +179,7 @@ export const spinner = ({
 				: code === 1
 					? styleText('red', S_STEP_CANCEL)
 					: styleText('red', S_STEP_ERROR);
-		_message = msg ?? _message;
+		_message = wrapTextWithPrefix(output, msg ?? _message, hasGuide ? prefix : '', '');
 		if (!silent) {
 			if (indicator === 'timer') {
 				output.write(`${step}  ${_message} ${formatTimer(_origin)}\n`);

--- a/packages/prompts/test/__snapshots__/progress-bar.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/progress-bar.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`prompts - progress (isCI = false) > message > sets message for next frame 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -15,7 +15,7 @@ exports[`prompts - progress (isCI = false) > message > sets message for next fra
 exports[`prompts - progress (isCI = false) > process exit handling > prioritizes cancel option over global setting 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Progress cancel message
 ",
@@ -26,7 +26,7 @@ exports[`prompts - progress (isCI = false) > process exit handling > prioritizes
 exports[`prompts - progress (isCI = false) > process exit handling > prioritizes error option over global setting 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Progress error message
 ",
@@ -37,7 +37,7 @@ exports[`prompts - progress (isCI = false) > process exit handling > prioritizes
 exports[`prompts - progress (isCI = false) > process exit handling > uses custom cancel message when provided directly 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Custom cancel message
 ",
@@ -48,7 +48,7 @@ exports[`prompts - progress (isCI = false) > process exit handling > uses custom
 exports[`prompts - progress (isCI = false) > process exit handling > uses custom error message when provided directly 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Custom error message
 ",
@@ -59,7 +59,7 @@ exports[`prompts - progress (isCI = false) > process exit handling > uses custom
 exports[`prompts - progress (isCI = false) > process exit handling > uses default cancel message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Canceled
 ",
@@ -70,7 +70,7 @@ exports[`prompts - progress (isCI = false) > process exit handling > uses defaul
 exports[`prompts - progress (isCI = false) > process exit handling > uses global custom cancel message from settings 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Global cancel message
 ",
@@ -81,7 +81,7 @@ exports[`prompts - progress (isCI = false) > process exit handling > uses global
 exports[`prompts - progress (isCI = false) > process exit handling > uses global custom error message from settings 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Global error message
 ",
@@ -92,7 +92,7 @@ exports[`prompts - progress (isCI = false) > process exit handling > uses global
 exports[`prompts - progress (isCI = false) > start > renders frames at interval 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -110,7 +110,7 @@ exports[`prompts - progress (isCI = false) > start > renders frames at interval 
 exports[`prompts - progress (isCI = false) > start > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m foo",
 ]
@@ -119,7 +119,7 @@ exports[`prompts - progress (isCI = false) > start > renders message 1`] = `
 exports[`prompts - progress (isCI = false) > start > renders timer when indicator is "timer" 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m  [0s]",
 ]
@@ -128,7 +128,7 @@ exports[`prompts - progress (isCI = false) > start > renders timer when indicato
 exports[`prompts - progress (isCI = false) > stop > renders cancel symbol when calling cancel() 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -142,7 +142,7 @@ exports[`prompts - progress (isCI = false) > stop > renders cancel symbol when c
 exports[`prompts - progress (isCI = false) > stop > renders error symbol when calling error() 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -156,7 +156,7 @@ exports[`prompts - progress (isCI = false) > stop > renders error symbol when ca
 exports[`prompts - progress (isCI = false) > stop > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -170,7 +170,7 @@ exports[`prompts - progress (isCI = false) > stop > renders message 1`] = `
 exports[`prompts - progress (isCI = false) > stop > renders message when cancelling 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -184,7 +184,7 @@ exports[`prompts - progress (isCI = false) > stop > renders message when cancell
 exports[`prompts - progress (isCI = false) > stop > renders message when erroring 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -198,7 +198,7 @@ exports[`prompts - progress (isCI = false) > stop > renders message when errorin
 exports[`prompts - progress (isCI = false) > stop > renders message without removing dots 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -212,7 +212,7 @@ exports[`prompts - progress (isCI = false) > stop > renders message without remo
 exports[`prompts - progress (isCI = false) > stop > renders submit symbol and stops progress 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -226,7 +226,7 @@ exports[`prompts - progress (isCI = false) > stop > renders submit symbol and st
 exports[`prompts - progress (isCI = false) > style > renders block progressbar 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m██████████[22m ",
   "<cursor.left count=1>",
@@ -249,7 +249,7 @@ exports[`prompts - progress (isCI = false) > style > renders block progressbar 1
 exports[`prompts - progress (isCI = false) > style > renders heavy progressbar 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━[22m ",
   "<cursor.left count=1>",
@@ -272,7 +272,7 @@ exports[`prompts - progress (isCI = false) > style > renders heavy progressbar 1
 exports[`prompts - progress (isCI = false) > style > renders light progressbar 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m──────────[22m ",
   "<cursor.left count=1>",
@@ -295,7 +295,7 @@ exports[`prompts - progress (isCI = false) > style > renders light progressbar 1
 exports[`prompts - progress (isCI = true) > message > sets message for next frame 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
   "
@@ -309,7 +309,7 @@ exports[`prompts - progress (isCI = true) > message > sets message for next fram
 exports[`prompts - progress (isCI = true) > process exit handling > prioritizes cancel option over global setting 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Progress cancel message
 ",
@@ -320,7 +320,7 @@ exports[`prompts - progress (isCI = true) > process exit handling > prioritizes 
 exports[`prompts - progress (isCI = true) > process exit handling > prioritizes error option over global setting 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Progress error message
 ",
@@ -331,7 +331,7 @@ exports[`prompts - progress (isCI = true) > process exit handling > prioritizes 
 exports[`prompts - progress (isCI = true) > process exit handling > uses custom cancel message when provided directly 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Custom cancel message
 ",
@@ -342,7 +342,7 @@ exports[`prompts - progress (isCI = true) > process exit handling > uses custom 
 exports[`prompts - progress (isCI = true) > process exit handling > uses custom error message when provided directly 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Custom error message
 ",
@@ -353,7 +353,7 @@ exports[`prompts - progress (isCI = true) > process exit handling > uses custom 
 exports[`prompts - progress (isCI = true) > process exit handling > uses default cancel message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Canceled
 ",
@@ -364,7 +364,7 @@ exports[`prompts - progress (isCI = true) > process exit handling > uses default
 exports[`prompts - progress (isCI = true) > process exit handling > uses global custom cancel message from settings 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Global cancel message
 ",
@@ -375,7 +375,7 @@ exports[`prompts - progress (isCI = true) > process exit handling > uses global 
 exports[`prompts - progress (isCI = true) > process exit handling > uses global custom error message from settings 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Global error message
 ",
@@ -386,7 +386,7 @@ exports[`prompts - progress (isCI = true) > process exit handling > uses global 
 exports[`prompts - progress (isCI = true) > start > renders frames at interval 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
 ]
@@ -395,7 +395,7 @@ exports[`prompts - progress (isCI = true) > start > renders frames at interval 1
 exports[`prompts - progress (isCI = true) > start > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m foo...",
 ]
@@ -404,7 +404,7 @@ exports[`prompts - progress (isCI = true) > start > renders message 1`] = `
 exports[`prompts - progress (isCI = true) > start > renders timer when indicator is "timer" 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
 ]
@@ -413,7 +413,7 @@ exports[`prompts - progress (isCI = true) > start > renders timer when indicator
 exports[`prompts - progress (isCI = true) > stop > renders cancel symbol when calling cancel() 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
   "
@@ -429,7 +429,7 @@ exports[`prompts - progress (isCI = true) > stop > renders cancel symbol when ca
 exports[`prompts - progress (isCI = true) > stop > renders error symbol when calling error() 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
   "
@@ -445,7 +445,7 @@ exports[`prompts - progress (isCI = true) > stop > renders error symbol when cal
 exports[`prompts - progress (isCI = true) > stop > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
   "
@@ -461,7 +461,7 @@ exports[`prompts - progress (isCI = true) > stop > renders message 1`] = `
 exports[`prompts - progress (isCI = true) > stop > renders message when cancelling 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
   "
@@ -477,7 +477,7 @@ exports[`prompts - progress (isCI = true) > stop > renders message when cancelli
 exports[`prompts - progress (isCI = true) > stop > renders message when erroring 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
   "
@@ -493,7 +493,7 @@ exports[`prompts - progress (isCI = true) > stop > renders message when erroring
 exports[`prompts - progress (isCI = true) > stop > renders message without removing dots 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
   "
@@ -509,7 +509,7 @@ exports[`prompts - progress (isCI = true) > stop > renders message without remov
 exports[`prompts - progress (isCI = true) > stop > renders submit symbol and stops progress 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[22m ...",
   "
@@ -525,7 +525,7 @@ exports[`prompts - progress (isCI = true) > stop > renders submit symbol and sto
 exports[`prompts - progress (isCI = true) > style > renders block progressbar 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m██████████[22m ...",
   "
@@ -546,7 +546,7 @@ exports[`prompts - progress (isCI = true) > style > renders block progressbar 1`
 exports[`prompts - progress (isCI = true) > style > renders heavy progressbar 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m━━━━━━━━━━[22m ...",
   "
@@ -567,7 +567,7 @@ exports[`prompts - progress (isCI = true) > style > renders heavy progressbar 1`
 exports[`prompts - progress (isCI = true) > style > renders light progressbar 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  [35m[39m[2m──────────[22m ...",
   "

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`spinner (isCI = false) > can be aborted by a signal 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Canceled
 ",
@@ -14,7 +14,7 @@ exports[`spinner (isCI = false) > can be aborted by a signal 1`] = `
 exports[`spinner (isCI = false) > clear > stops and clears the spinner from the output 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  Loading",
   "<cursor.left count=1>",
@@ -38,7 +38,7 @@ exports[`spinner (isCI = false) > global withGuide: false removes guide 1`] = `
 exports[`spinner (isCI = false) > indicator customization > custom delay 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -61,7 +61,7 @@ exports[`spinner (isCI = false) > indicator customization > custom delay 1`] = `
 exports[`spinner (isCI = false) > indicator customization > custom frame style 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m◒[39m  ",
   "<cursor.left count=1>",
@@ -84,7 +84,7 @@ exports[`spinner (isCI = false) > indicator customization > custom frame style 1
 exports[`spinner (isCI = false) > indicator customization > custom frames 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m🐴[39m  ",
   "<cursor.left count=1>",
@@ -107,7 +107,7 @@ exports[`spinner (isCI = false) > indicator customization > custom frames 1`] = 
 exports[`spinner (isCI = false) > indicator customization > custom frames with lots of frame have consistent ellipsis display 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m0[39m  ",
   "<cursor.left count=1>",
@@ -307,10 +307,23 @@ exports[`spinner (isCI = false) > indicator customization > custom frames with l
 ]
 `;
 
+exports[`spinner (isCI = false) > lines are indented as expected 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m  
+",
+  "[32m◇[39m  Foo
+[90m│[39m  Bar
+[90m│[39m  Biz
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`spinner (isCI = false) > message > sets message for next frame 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -327,7 +340,7 @@ exports[`spinner (isCI = false) > message > sets message for next frame 1`] = `
 exports[`spinner (isCI = false) > process exit handling > prioritizes cancel option over global setting 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Spinner cancel message
 ",
@@ -338,7 +351,7 @@ exports[`spinner (isCI = false) > process exit handling > prioritizes cancel opt
 exports[`spinner (isCI = false) > process exit handling > prioritizes error option over global setting 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Spinner error message
 ",
@@ -349,7 +362,7 @@ exports[`spinner (isCI = false) > process exit handling > prioritizes error opti
 exports[`spinner (isCI = false) > process exit handling > uses custom cancel message when provided directly 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Custom cancel message
 ",
@@ -360,7 +373,7 @@ exports[`spinner (isCI = false) > process exit handling > uses custom cancel mes
 exports[`spinner (isCI = false) > process exit handling > uses custom error message when provided directly 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Custom error message
 ",
@@ -371,7 +384,7 @@ exports[`spinner (isCI = false) > process exit handling > uses custom error mess
 exports[`spinner (isCI = false) > process exit handling > uses default cancel message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Canceled
 ",
@@ -382,7 +395,7 @@ exports[`spinner (isCI = false) > process exit handling > uses default cancel me
 exports[`spinner (isCI = false) > process exit handling > uses global custom cancel message from settings 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Global cancel message
 ",
@@ -393,7 +406,7 @@ exports[`spinner (isCI = false) > process exit handling > uses global custom can
 exports[`spinner (isCI = false) > process exit handling > uses global custom error message from settings 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Global error message
 ",
@@ -404,11 +417,11 @@ exports[`spinner (isCI = false) > process exit handling > uses global custom err
 exports[`spinner (isCI = false) > start > handles multi-line messages 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  foo
-bar
-baz",
+[90m│[39m  bar
+[90m│[39m  baz",
   "<cursor.up count=2>",
   "<cursor.left count=1>",
   "<erase.down>",
@@ -421,10 +434,10 @@ baz",
 exports[`spinner (isCI = false) > start > handles wrapping 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
-  "[35m◒[39m  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-xxxxxxxxxxxxx",
+  "[35m◒[39m  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+[90m│[39m  xxxxxxxxxxxxxxxxxxxxxxx",
   "<cursor.up count=1>",
   "<cursor.left count=1>",
   "<erase.down>",
@@ -437,7 +450,7 @@ xxxxxxxxxxxxx",
 exports[`spinner (isCI = false) > start > renders frames at interval 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -460,7 +473,7 @@ exports[`spinner (isCI = false) > start > renders frames at interval 1`] = `
 exports[`spinner (isCI = false) > start > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  foo",
   "<cursor.left count=1>",
@@ -474,7 +487,7 @@ exports[`spinner (isCI = false) > start > renders message 1`] = `
 exports[`spinner (isCI = false) > start > renders timer when indicator is "timer" 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m   [0s]",
   "<cursor.left count=1>",
@@ -488,7 +501,7 @@ exports[`spinner (isCI = false) > start > renders timer when indicator is "timer
 exports[`spinner (isCI = false) > stop > renders cancel symbol when calling cancel() 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -502,7 +515,7 @@ exports[`spinner (isCI = false) > stop > renders cancel symbol when calling canc
 exports[`spinner (isCI = false) > stop > renders error symbol when calling error() 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -516,7 +529,7 @@ exports[`spinner (isCI = false) > stop > renders error symbol when calling error
 exports[`spinner (isCI = false) > stop > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -530,7 +543,7 @@ exports[`spinner (isCI = false) > stop > renders message 1`] = `
 exports[`spinner (isCI = false) > stop > renders message when cancelling 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -544,7 +557,7 @@ exports[`spinner (isCI = false) > stop > renders message when cancelling 1`] = `
 exports[`spinner (isCI = false) > stop > renders message when erroring 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -558,7 +571,7 @@ exports[`spinner (isCI = false) > stop > renders message when erroring 1`] = `
 exports[`spinner (isCI = false) > stop > renders message without removing dots 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -572,7 +585,7 @@ exports[`spinner (isCI = false) > stop > renders message without removing dots 1
 exports[`spinner (isCI = false) > stop > renders submit symbol and stops spinner 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ",
   "<cursor.left count=1>",
@@ -598,7 +611,7 @@ exports[`spinner (isCI = false) > withGuide: false removes guide 1`] = `
 exports[`spinner (isCI = true) > can be aborted by a signal 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Canceled
 ",
@@ -609,7 +622,7 @@ exports[`spinner (isCI = true) > can be aborted by a signal 1`] = `
 exports[`spinner (isCI = true) > clear > stops and clears the spinner from the output 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  Loading...",
   "
@@ -637,7 +650,7 @@ exports[`spinner (isCI = true) > global withGuide: false removes guide 1`] = `
 exports[`spinner (isCI = true) > indicator customization > custom delay 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -653,7 +666,7 @@ exports[`spinner (isCI = true) > indicator customization > custom delay 1`] = `
 exports[`spinner (isCI = true) > indicator customization > custom frame style 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m◒[39m  ...",
   "
@@ -669,7 +682,7 @@ exports[`spinner (isCI = true) > indicator customization > custom frame style 1`
 exports[`spinner (isCI = true) > indicator customization > custom frames 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m🐴[39m  ...",
   "
@@ -685,7 +698,7 @@ exports[`spinner (isCI = true) > indicator customization > custom frames 1`] = `
 exports[`spinner (isCI = true) > indicator customization > custom frames with lots of frame have consistent ellipsis display 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m0[39m  ...",
   "
@@ -698,10 +711,23 @@ exports[`spinner (isCI = true) > indicator customization > custom frames with lo
 ]
 `;
 
+exports[`spinner (isCI = true) > lines are indented as expected 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m  
+",
+  "[32m◇[39m  Foo
+[90m│[39m  Bar
+[90m│[39m  Biz
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`spinner (isCI = true) > message > sets message for next frame 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -722,7 +748,7 @@ exports[`spinner (isCI = true) > message > sets message for next frame 1`] = `
 exports[`spinner (isCI = true) > process exit handling > prioritizes cancel option over global setting 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Spinner cancel message
 ",
@@ -733,7 +759,7 @@ exports[`spinner (isCI = true) > process exit handling > prioritizes cancel opti
 exports[`spinner (isCI = true) > process exit handling > prioritizes error option over global setting 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Spinner error message
 ",
@@ -744,7 +770,7 @@ exports[`spinner (isCI = true) > process exit handling > prioritizes error optio
 exports[`spinner (isCI = true) > process exit handling > uses custom cancel message when provided directly 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Custom cancel message
 ",
@@ -755,7 +781,7 @@ exports[`spinner (isCI = true) > process exit handling > uses custom cancel mess
 exports[`spinner (isCI = true) > process exit handling > uses custom error message when provided directly 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Custom error message
 ",
@@ -766,7 +792,7 @@ exports[`spinner (isCI = true) > process exit handling > uses custom error messa
 exports[`spinner (isCI = true) > process exit handling > uses default cancel message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Canceled
 ",
@@ -777,7 +803,7 @@ exports[`spinner (isCI = true) > process exit handling > uses default cancel mes
 exports[`spinner (isCI = true) > process exit handling > uses global custom cancel message from settings 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m■[39m  Global cancel message
 ",
@@ -788,7 +814,7 @@ exports[`spinner (isCI = true) > process exit handling > uses global custom canc
 exports[`spinner (isCI = true) > process exit handling > uses global custom error message from settings 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[31m▲[39m  Global error message
 ",
@@ -799,11 +825,11 @@ exports[`spinner (isCI = true) > process exit handling > uses global custom erro
 exports[`spinner (isCI = true) > start > handles multi-line messages 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  foo
-bar
-baz...",
+[90m│[39m  bar
+[90m│[39m  baz...",
   "
 ",
   "<cursor.up count=2>",
@@ -818,10 +844,10 @@ baz...",
 exports[`spinner (isCI = true) > start > handles wrapping 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
-  "[35m◒[39m  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-xxxxxxxxxxxxx...",
+  "[35m◒[39m  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+[90m│[39m  xxxxxxxxxxxxxxxxxxxxxxx...",
   "
 ",
   "<cursor.up count=1>",
@@ -836,7 +862,7 @@ xxxxxxxxxxxxx...",
 exports[`spinner (isCI = true) > start > renders frames at interval 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -852,7 +878,7 @@ exports[`spinner (isCI = true) > start > renders frames at interval 1`] = `
 exports[`spinner (isCI = true) > start > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  foo...",
   "
@@ -868,7 +894,7 @@ exports[`spinner (isCI = true) > start > renders message 1`] = `
 exports[`spinner (isCI = true) > start > renders timer when indicator is "timer" 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -884,7 +910,7 @@ exports[`spinner (isCI = true) > start > renders timer when indicator is "timer"
 exports[`spinner (isCI = true) > stop > renders cancel symbol when calling cancel() 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -900,7 +926,7 @@ exports[`spinner (isCI = true) > stop > renders cancel symbol when calling cance
 exports[`spinner (isCI = true) > stop > renders error symbol when calling error() 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -916,7 +942,7 @@ exports[`spinner (isCI = true) > stop > renders error symbol when calling error(
 exports[`spinner (isCI = true) > stop > renders message 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -932,7 +958,7 @@ exports[`spinner (isCI = true) > stop > renders message 1`] = `
 exports[`spinner (isCI = true) > stop > renders message when cancelling 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -948,7 +974,7 @@ exports[`spinner (isCI = true) > stop > renders message when cancelling 1`] = `
 exports[`spinner (isCI = true) > stop > renders message when erroring 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -964,7 +990,7 @@ exports[`spinner (isCI = true) > stop > renders message when erroring 1`] = `
 exports[`spinner (isCI = true) > stop > renders message without removing dots 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "
@@ -980,7 +1006,7 @@ exports[`spinner (isCI = true) > stop > renders message without removing dots 1`
 exports[`spinner (isCI = true) > stop > renders submit symbol and stops spinner 1`] = `
 [
   "<cursor.hide>",
-  "[90m│[39m
+  "[90m│[39m  
 ",
   "[35m◒[39m  ...",
   "

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -53,6 +53,19 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			expect(output.buffer).toMatchSnapshot();
 		});
 
+		test('handles wrapping', () => {
+			const columns = getColumns(output);
+			const result = prompts.spinner({ output });
+
+			result.start('x'.repeat(columns + 10));
+
+			vi.advanceTimersByTime(80);
+
+			result.stop('stopped');
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
 		test('renders message', () => {
 			const result = prompts.spinner({ output });
 
@@ -73,19 +86,6 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			vi.advanceTimersByTime(80);
 
 			result.stop();
-
-			expect(output.buffer).toMatchSnapshot();
-		});
-
-		test('handles wrapping', () => {
-			const columns = getColumns(output);
-			const result = prompts.spinner({ output });
-
-			result.start('x'.repeat(columns + 10));
-
-			vi.advanceTimersByTime(80);
-
-			result.stop('stopped');
 
 			expect(output.buffer).toMatchSnapshot();
 		});
@@ -423,6 +423,20 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 		result.start('Testing');
 
 		controller.abort();
+
+		expect(output.buffer).toMatchSnapshot();
+	});
+
+	test('lines are indented as expected', async () => {
+		const controller = new AbortController();
+		const result = prompts.spinner({
+			output,
+			signal: controller.signal,
+		});
+
+		result.start('Testing\n1, 2, 3');
+
+		result.stop('Foo\nBar\nBiz');
 
 		expect(output.buffer).toMatchSnapshot();
 	});


### PR DESCRIPTION
## What does this PR do?

makes sure the printed messages in `spinner` and its dependent prompts are correctly wrapped and indented.

<details>
<summary>Screenshots</summary>

Before:

<img width="917" height="73" alt="image" src="https://github.com/user-attachments/assets/44f06638-f158-4476-a841-6908bc9c45df" />

<img width="459" height="231" alt="image" src="https://github.com/user-attachments/assets/655db9f8-2def-4226-a713-aac15a06e99a" />

After:

<img width="847" height="73" alt="image" src="https://github.com/user-attachments/assets/fab621ba-f6d3-483b-b56c-068e06de79e2" />

<img width="437" height="309" alt="image" src="https://github.com/user-attachments/assets/b1aeb97a-4e06-4894-a574-385a37a5bddf" />

</details>

## Type of change

<!-- Check one. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

---

i spotted #479 which might also fix this issue, but it seems to have lost momentum and i think this is a reasonable patch until it's done