### PR TITLE
fix(prompts): style box guide bar to match other gutters

### DIFF
--- a/.changeset/box-guide-colour.md
+++ b/.changeset/box-guide-colour.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Style the guide bar rendered by `box({ withGuide: true })` in grey so it matches the gutter drawn by `log`, `note` and the spinner

--- a/packages/prompts/src/box.ts
+++ b/packages/prompts/src/box.ts
@@ -1,4 +1,5 @@
 import type { Writable } from 'node:stream';
+import { styleText } from 'node:util';
 import { getColumns, settings } from '@clack/core';
 import stringWidth from 'fast-string-width';
 import { wrapAnsi } from 'fast-wrap-ansi';
@@ -129,7 +130,7 @@ export const box = (message = '', title = '', opts?: BoxOptions) => {
 	const contentPadding = opts?.contentPadding ?? 2;
 	const width = opts?.width === undefined || opts.width === 'auto' ? 1 : Math.min(1, opts.width);
 	const hasGuide = opts?.withGuide ?? settings.withGuide;
-	const linePrefix = !hasGuide ? '' : `${S_BAR} `;
+	const linePrefix = !hasGuide ? '' : `${styleText('gray', S_BAR)} `;
 	const formatBorder = opts?.formatBorder ?? defaultFormatBorder;
 	const symbols = (opts?.rounded ? roundedSymbols : squareSymbols).map(formatBorder);
 	const hSymbol = formatBorder(S_BAR_H);

--- a/packages/prompts/test/__snapshots__/box.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/box.test.ts.snap
@@ -2,234 +2,234 @@
 
 exports[`box (isCI = false) > cannot have width larger than 100% 1`] = `
 [
-  "│ ┌─title──────────────────────────────────────────────────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────────────────────────────────────────────────┐
 ",
-  "│ │  message                                                                   │
+  "[90m│[39m │  message                                                                   │
 ",
-  "│ └────────────────────────────────────────────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────────────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders as specified width 1`] = `
 [
-  "│ ┌─title──────────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────────┐
 ",
-  "│ │  short                             │
+  "[90m│[39m │  short                             │
 ",
-  "│ │  somewhat questionably long line   │
+  "[90m│[39m │  somewhat questionably long line   │
 ",
-  "│ └────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders as wide as longest line with width: auto 1`] = `
 [
-  "│ ┌─title──────────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────────┐
 ",
-  "│ │  short                             │
+  "[90m│[39m │  short                             │
 ",
-  "│ │  somewhat questionably long line   │
+  "[90m│[39m │  somewhat questionably long line   │
 ",
-  "│ └────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders auto width with content longer than title 1`] = `
 [
-  "│ ┌─title──────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────┐
 ",
-  "│ │  messagemessagemessagemessage  │
+  "[90m│[39m │  messagemessagemessagemessage  │
 ",
-  "│ └────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders auto width with title longer than content 1`] = `
 [
-  "│ ┌─titletitletitletitle─┐
+  "[90m│[39m ┌─titletitletitletitle─┐
 ",
-  "│ │  message             │
+  "[90m│[39m │  message             │
 ",
-  "│ └──────────────────────┘
+  "[90m│[39m └──────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders center aligned content 1`] = `
 [
-  "│ ┌─title──────┐
+  "[90m│[39m ┌─title──────┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders center aligned title 1`] = `
 [
-  "│ ┌───title────┐
+  "[90m│[39m ┌───title────┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders left aligned content 1`] = `
 [
-  "│ ┌─title──────┐
+  "[90m│[39m ┌─title──────┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders left aligned title 1`] = `
 [
-  "│ ┌─title──────┐
+  "[90m│[39m ┌─title──────┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders message 1`] = `
 [
-  "│ ┌────────────────────────────────────────────────────────────────────────────┐
+  "[90m│[39m ┌────────────────────────────────────────────────────────────────────────────┐
 ",
-  "│ │  message                                                                   │
+  "[90m│[39m │  message                                                                   │
 ",
-  "│ └────────────────────────────────────────────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────────────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders message with title 1`] = `
 [
-  "│ ┌─some title─────────────────────────────────────────────────────────────────┐
+  "[90m│[39m ┌─some title─────────────────────────────────────────────────────────────────┐
 ",
-  "│ │  message                                                                   │
+  "[90m│[39m │  message                                                                   │
 ",
-  "│ └────────────────────────────────────────────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────────────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders right aligned content 1`] = `
 [
-  "│ ┌─title──────┐
+  "[90m│[39m ┌─title──────┐
 ",
-  "│ │   message  │
+  "[90m│[39m │   message  │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders right aligned title 1`] = `
 [
-  "│ ┌──────title─┐
+  "[90m│[39m ┌──────title─┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders rounded corners when rounded is true 1`] = `
 [
-  "│ ╭─title──────╮
+  "[90m│[39m ╭─title──────╮
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ ╰────────────╯
+  "[90m│[39m ╰────────────╯
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders specified contentPadding 1`] = `
 [
-  "│ ┌─title──────────────┐
+  "[90m│[39m ┌─title──────────────┐
 ",
-  "│ │      message       │
+  "[90m│[39m │      message       │
 ",
-  "│ └────────────────────┘
+  "[90m│[39m └────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders specified titlePadding 1`] = `
 [
-  "│ ┌──────title───────┐
+  "[90m│[39m ┌──────title───────┐
 ",
-  "│ │  message         │
+  "[90m│[39m │  message         │
 ",
-  "│ └──────────────────┘
+  "[90m│[39m └──────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders truncated long titles 1`] = `
 [
-  "│ ┌─foofoof...─┐
+  "[90m│[39m ┌─foofoof...─┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders wide characters with auto width 1`] = `
 [
-  "│ ┌─这是标题─────────────────┐
+  "[90m│[39m ┌─这是标题─────────────────┐
 ",
-  "│ │  이게 첫 번째 줄이에요   │
+  "[90m│[39m │  이게 첫 번째 줄이에요   │
 ",
-  "│ │  これは次の行です        │
+  "[90m│[39m │  これは次の行です        │
 ",
-  "│ └──────────────────────────┘
+  "[90m│[39m └──────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders wide characters with specified width 1`] = `
 [
-  "│ ┌─这是标题───┐
+  "[90m│[39m ┌─这是标题───┐
 ",
-  "│ │  이게 첫   │
+  "[90m│[39m │  이게 첫   │
 ",
-  "│ │  번째      │
+  "[90m│[39m │  번째      │
 ",
-  "│ │  줄이에요  │
+  "[90m│[39m │  줄이에요  │
 ",
-  "│ │  これは次  │
+  "[90m│[39m │  これは次  │
 ",
-  "│ │  の行です  │
+  "[90m│[39m │  の行です  │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = false) > renders with formatBorder formatting 1`] = `
 [
-  "│ [31m┌[39m[31m─[39mtitle[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m┐[39m
+  "[90m│[39m [31m┌[39m[31m─[39mtitle[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m┐[39m
 ",
-  "│ [31m│[39m  message   [31m│[39m
+  "[90m│[39m [31m│[39m  message   [31m│[39m
 ",
-  "│ [31m└[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m┘[39m
+  "[90m│[39m [31m└[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m┘[39m
 ",
 ]
 `;
@@ -258,253 +258,253 @@ exports[`box (isCI = false) > renders without guide when withGuide is false 1`] 
 
 exports[`box (isCI = false) > wraps content to fit within specified width 1`] = `
 [
-  "│ ┌─title──────────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────────┐
 ",
-  "│ │  foo barfoo barfoo barfoo barfoo   │
+  "[90m│[39m │  foo barfoo barfoo barfoo barfoo   │
 ",
-  "│ │  barfoo barfoo barfoo barfoo       │
+  "[90m│[39m │  barfoo barfoo barfoo barfoo       │
 ",
-  "│ │  barfoo barfoo barfoo barfoo       │
+  "[90m│[39m │  barfoo barfoo barfoo barfoo       │
 ",
-  "│ │  barfoo barfoo barfoo barfoo       │
+  "[90m│[39m │  barfoo barfoo barfoo barfoo       │
 ",
-  "│ │  barfoo barfoo barfoo bar          │
+  "[90m│[39m │  barfoo barfoo barfoo bar          │
 ",
-  "│ └────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > cannot have width larger than 100% 1`] = `
 [
-  "│ ┌─title──────────────────────────────────────────────────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────────────────────────────────────────────────┐
 ",
-  "│ │  message                                                                   │
+  "[90m│[39m │  message                                                                   │
 ",
-  "│ └────────────────────────────────────────────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────────────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders as specified width 1`] = `
 [
-  "│ ┌─title──────────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────────┐
 ",
-  "│ │  short                             │
+  "[90m│[39m │  short                             │
 ",
-  "│ │  somewhat questionably long line   │
+  "[90m│[39m │  somewhat questionably long line   │
 ",
-  "│ └────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders as wide as longest line with width: auto 1`] = `
 [
-  "│ ┌─title──────────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────────┐
 ",
-  "│ │  short                             │
+  "[90m│[39m │  short                             │
 ",
-  "│ │  somewhat questionably long line   │
+  "[90m│[39m │  somewhat questionably long line   │
 ",
-  "│ └────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders auto width with content longer than title 1`] = `
 [
-  "│ ┌─title──────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────┐
 ",
-  "│ │  messagemessagemessagemessage  │
+  "[90m│[39m │  messagemessagemessagemessage  │
 ",
-  "│ └────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders auto width with title longer than content 1`] = `
 [
-  "│ ┌─titletitletitletitle─┐
+  "[90m│[39m ┌─titletitletitletitle─┐
 ",
-  "│ │  message             │
+  "[90m│[39m │  message             │
 ",
-  "│ └──────────────────────┘
+  "[90m│[39m └──────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders center aligned content 1`] = `
 [
-  "│ ┌─title──────┐
+  "[90m│[39m ┌─title──────┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders center aligned title 1`] = `
 [
-  "│ ┌───title────┐
+  "[90m│[39m ┌───title────┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders left aligned content 1`] = `
 [
-  "│ ┌─title──────┐
+  "[90m│[39m ┌─title──────┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders left aligned title 1`] = `
 [
-  "│ ┌─title──────┐
+  "[90m│[39m ┌─title──────┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders message 1`] = `
 [
-  "│ ┌────────────────────────────────────────────────────────────────────────────┐
+  "[90m│[39m ┌────────────────────────────────────────────────────────────────────────────┐
 ",
-  "│ │  message                                                                   │
+  "[90m│[39m │  message                                                                   │
 ",
-  "│ └────────────────────────────────────────────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────────────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders message with title 1`] = `
 [
-  "│ ┌─some title─────────────────────────────────────────────────────────────────┐
+  "[90m│[39m ┌─some title─────────────────────────────────────────────────────────────────┐
 ",
-  "│ │  message                                                                   │
+  "[90m│[39m │  message                                                                   │
 ",
-  "│ └────────────────────────────────────────────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────────────────────────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders right aligned content 1`] = `
 [
-  "│ ┌─title──────┐
+  "[90m│[39m ┌─title──────┐
 ",
-  "│ │   message  │
+  "[90m│[39m │   message  │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders right aligned title 1`] = `
 [
-  "│ ┌──────title─┐
+  "[90m│[39m ┌──────title─┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders rounded corners when rounded is true 1`] = `
 [
-  "│ ╭─title──────╮
+  "[90m│[39m ╭─title──────╮
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ ╰────────────╯
+  "[90m│[39m ╰────────────╯
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders specified contentPadding 1`] = `
 [
-  "│ ┌─title──────────────┐
+  "[90m│[39m ┌─title──────────────┐
 ",
-  "│ │      message       │
+  "[90m│[39m │      message       │
 ",
-  "│ └────────────────────┘
+  "[90m│[39m └────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders specified titlePadding 1`] = `
 [
-  "│ ┌──────title───────┐
+  "[90m│[39m ┌──────title───────┐
 ",
-  "│ │  message         │
+  "[90m│[39m │  message         │
 ",
-  "│ └──────────────────┘
+  "[90m│[39m └──────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders truncated long titles 1`] = `
 [
-  "│ ┌─foofoof...─┐
+  "[90m│[39m ┌─foofoof...─┐
 ",
-  "│ │  message   │
+  "[90m│[39m │  message   │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders wide characters with auto width 1`] = `
 [
-  "│ ┌─这是标题─────────────────┐
+  "[90m│[39m ┌─这是标题─────────────────┐
 ",
-  "│ │  이게 첫 번째 줄이에요   │
+  "[90m│[39m │  이게 첫 번째 줄이에요   │
 ",
-  "│ │  これは次の行です        │
+  "[90m│[39m │  これは次の行です        │
 ",
-  "│ └──────────────────────────┘
+  "[90m│[39m └──────────────────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders wide characters with specified width 1`] = `
 [
-  "│ ┌─这是标题───┐
+  "[90m│[39m ┌─这是标题───┐
 ",
-  "│ │  이게 첫   │
+  "[90m│[39m │  이게 첫   │
 ",
-  "│ │  번째      │
+  "[90m│[39m │  번째      │
 ",
-  "│ │  줄이에요  │
+  "[90m│[39m │  줄이에요  │
 ",
-  "│ │  これは次  │
+  "[90m│[39m │  これは次  │
 ",
-  "│ │  の行です  │
+  "[90m│[39m │  の行です  │
 ",
-  "│ └────────────┘
+  "[90m│[39m └────────────┘
 ",
 ]
 `;
 
 exports[`box (isCI = true) > renders with formatBorder formatting 1`] = `
 [
-  "│ [31m┌[39m[31m─[39mtitle[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m┐[39m
+  "[90m│[39m [31m┌[39m[31m─[39mtitle[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m┐[39m
 ",
-  "│ [31m│[39m  message   [31m│[39m
+  "[90m│[39m [31m│[39m  message   [31m│[39m
 ",
-  "│ [31m└[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m┘[39m
+  "[90m│[39m [31m└[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m─[39m[31m┘[39m
 ",
 ]
 `;
@@ -533,19 +533,19 @@ exports[`box (isCI = true) > renders without guide when withGuide is false 1`] =
 
 exports[`box (isCI = true) > wraps content to fit within specified width 1`] = `
 [
-  "│ ┌─title──────────────────────────────┐
+  "[90m│[39m ┌─title──────────────────────────────┐
 ",
-  "│ │  foo barfoo barfoo barfoo barfoo   │
+  "[90m│[39m │  foo barfoo barfoo barfoo barfoo   │
 ",
-  "│ │  barfoo barfoo barfoo barfoo       │
+  "[90m│[39m │  barfoo barfoo barfoo barfoo       │
 ",
-  "│ │  barfoo barfoo barfoo barfoo       │
+  "[90m│[39m │  barfoo barfoo barfoo barfoo       │
 ",
-  "│ │  barfoo barfoo barfoo barfoo       │
+  "[90m│[39m │  barfoo barfoo barfoo barfoo       │
 ",
-  "│ │  barfoo barfoo barfoo bar          │
+  "[90m│[39m │  barfoo barfoo barfoo bar          │
 ",
-  "│ └────────────────────────────────────┘
+  "[90m│[39m └────────────────────────────────────┘
 ",
 ]
 `;

--- a/packages/prompts/test/box.test.ts
+++ b/packages/prompts/test/box.test.ts
@@ -98,6 +98,23 @@ describe.each(['true', 'false'])('box (isCI = %s)', (isCI) => {
 		expect(output.buffer).toMatchSnapshot();
 	});
 
+	test('renders the guide in the same style as log', () => {
+		const logOutput = new MockWritable();
+		prompts.log.info('message', { input, output: logOutput });
+		const [logGuide] = logOutput.buffer.join('').split('\n');
+
+		prompts.box('message', 'title', {
+			input,
+			output,
+			width: 'auto',
+			formatBorder: (text) => styleText('green', text),
+		});
+
+		for (const line of output.buffer) {
+			expect(line.startsWith(`${logGuide} `)).toBe(true);
+		}
+	});
+
 	test('renders without guide when withGuide is false', () => {
 		prompts.box('message', 'title', {
 			input,


### PR DESCRIPTION
## What does this PR do?

noticed this when working on https://github.com/nuxt/cli/pull/1386 - the guide for boxes was a brighter grey/white than everywhere else

it seems like a straightforward fix 🙏

I couldn't find any issue tracking

## Type of change

<!-- Check one. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code
