### PR TITLE
chore: stop publishing CHANGELOG.md to npm

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://github.com/bombshell-dev/clack/tree/main/packages/core#readme",
   "files": [
-    "dist",
-    "CHANGELOG.md"
+    "dist"
   ],
   "keywords": [
     "ask",

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://github.com/bombshell-dev/clack/tree/main/packages/prompts#readme",
   "files": [
-    "dist",
-    "CHANGELOG.md"
+    "dist"
   ],
   "author": {
     "name": "Nate Moore",


### PR DESCRIPTION
## What does this PR do?

Stop publishing `CHANGELOG.md` to npm

Closes #

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
