### PR TITLE
feat(prompts): add tab-completion to path prompt

### DIFF
--- a/.changeset/modern-views-stay.md
+++ b/.changeset/modern-views-stay.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": minor
+"@clack/core": minor
+---
+
+Add tab-completion to the `path` prompt: pressing Tab fills the input with the focused suggestion, so you can quickly descend into deep directories (type `/` and Tab again). Powered by a new opt-in `completeOnTab` option on `autocomplete`, which also shows a `Tab: complete` hint in the instructions footer. Default `autocomplete` behavior is unchanged.

--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -58,6 +58,11 @@ export interface AutocompleteOptions<T extends OptionLike>
 	 * the prompt's filter (so the value remains selectable).
 	 */
 	placeholder?: string;
+	/**
+	 * When `true` (single-select only), pressing Tab fills the input with the
+	 * currently focused option's value, as if the user had typed it.
+	 */
+	completeOnTab?: boolean;
 }
 
 export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
@@ -74,6 +79,7 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 	#filterFn: FilterFunction<T> | undefined;
 	#options: T[] | (() => T[]);
 	#placeholder: string | undefined;
+	#completeOnTab: boolean;
 
 	get cursor(): number {
 		return this.#cursor;
@@ -104,6 +110,7 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 
 		this.#options = opts.options;
 		this.#placeholder = opts.placeholder;
+		this.#completeOnTab = opts.completeOnTab === true;
 		const options = this.options;
 		this.filteredOptions = [...options];
 		this.multiple = opts.multiple === true;
@@ -170,6 +177,20 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 				this._clearUserInput();
 			}
 			this._setUserInput(placeholder, true);
+			this.isNavigating = false;
+			return;
+		}
+
+		// Tab completion: fill input with the focused option's value
+		if (
+			key.name === 'tab' &&
+			this.#completeOnTab &&
+			!this.multiple &&
+			this.focusedValue !== undefined
+		) {
+			const completion = String(this.focusedValue); // capture before clearing resets focusedValue
+			this._clearUserInput();
+			this._setUserInput(completion, true);
 			this.isNavigating = false;
 			return;
 		}

--- a/packages/core/test/prompts/autocomplete.test.ts
+++ b/packages/core/test/prompts/autocomplete.test.ts
@@ -272,4 +272,60 @@ describe('AutocompletePrompt', () => {
 		// Placeholder does not match any option, so input must not be filled with placeholder
 		expect(instance.userInput).not.to.equal('Type to search...');
 	});
+
+	test('completeOnTab fills input with focused option and submit returns it', async () => {
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: testOptions,
+			completeOnTab: true,
+		});
+
+		const promise = instance.prompt();
+		input.emit('keypress', 'b', { name: 'b' });
+		input.emit('keypress', 'a', { name: 'a' });
+		input.emit('keypress', 'n', { name: 'n' });
+		input.emit('keypress', '\t', { name: 'tab' });
+		input.emit('keypress', '', { name: 'return' });
+		const result = await promise;
+
+		expect(instance.userInput).to.equal('banana');
+		expect(result).to.equal('banana');
+	});
+
+	test('completeOnTab with no matches leaves input unchanged', () => {
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: testOptions,
+			completeOnTab: true,
+		});
+
+		instance.prompt();
+		input.emit('keypress', 'z', { name: 'z' });
+		input.emit('keypress', 'z', { name: 'z' });
+		input.emit('keypress', 'z', { name: 'z' });
+		input.emit('keypress', '\t', { name: 'tab' });
+
+		expect(instance.userInput).to.equal('zzz');
+	});
+
+	test('Tab does not complete when completeOnTab is not set', () => {
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: testOptions,
+		});
+
+		instance.prompt();
+		input.emit('keypress', 'b', { name: 'b' });
+		input.emit('keypress', 'a', { name: 'a' });
+		input.emit('keypress', 'n', { name: 'n' });
+		input.emit('keypress', '\t', { name: 'tab' });
+
+		expect(instance.userInput).to.equal('ban');
+	});
 });

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -93,6 +93,12 @@ export interface AutocompleteOptions<Value> extends AutocompleteSharedOptions<Va
 	 * The starting value shown in the users input box.
 	 */
 	initialUserInput?: string;
+
+	/**
+	 * When `true`, pressing Tab fills the input with the currently focused
+	 * option's value, as if the user had typed it.
+	 */
+	completeOnTab?: boolean;
 }
 
 /**
@@ -126,6 +132,7 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 		initialValue: opts.initialValue ? [opts.initialValue] : undefined,
 		initialUserInput: opts.initialUserInput,
 		placeholder: opts.placeholder,
+		completeOnTab: opts.completeOnTab,
 		filter:
 			opts.filter ??
 			((search: string, opt: Option<Value>) => {
@@ -223,6 +230,7 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 					// Show instructions
 					const instructions = [
 						`${styleText('dim', '↑/↓')} to select`,
+						...(opts.completeOnTab ? [`${styleText('dim', 'Tab:')} complete`] : []),
 						`${styleText('dim', 'Enter:')} confirm`,
 						`${styleText('dim', 'Type:')} to search`,
 					];

--- a/packages/prompts/src/path.ts
+++ b/packages/prompts/src/path.ts
@@ -65,6 +65,7 @@ export const path = (opts: PathOptions) => {
 		...opts,
 		initialUserInput: opts.initialValue ?? opts.root ?? process.cwd(),
 		maxItems: 5,
+		completeOnTab: true,
 		validate(value) {
 			if (Array.isArray(value)) {
 				// Shouldn't ever happen since we don't enable `multiple: true`

--- a/packages/prompts/test/__snapshots__/path.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/path.test.ts.snap
@@ -11,7 +11,7 @@ exports[`text (isCI = false) > can cancel 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=1>",
@@ -35,14 +35,14 @@ exports[`text (isCI = false) > cannot submit unknown value 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/_█
 [36m│[39m  [33mNo matches found[39m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -52,7 +52,7 @@ exports[`text (isCI = false) > cannot submit unknown value 1`] = `
 [33m│[39m  [2mSearch:[22m /tmp/_█
 [33m│[39m  [33mNo matches found[39m
 [33m│[39m  [33mPlease select a path[39m
-[33m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[33m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [33m└[39m",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
@@ -64,14 +64,14 @@ exports[`text (isCI = false) > cannot submit unknown value 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/b█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -92,7 +92,7 @@ exports[`text (isCI = false) > initialValue sets the value 1`] = `
 [36m│[39m
 [36m│[39m  [2mSearch:[22m /tmp/bar█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -116,14 +116,14 @@ exports[`text (isCI = false) > renders cancelled value if one set 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/x█
 [36m│[39m  [33mNo matches found[39m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=3>",
@@ -152,7 +152,7 @@ exports[`text (isCI = false) > renders message 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=1>",
@@ -176,14 +176,14 @@ exports[`text (isCI = false) > renders submitted value 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/b█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=3>",
@@ -201,6 +201,96 @@ exports[`text (isCI = false) > renders submitted value 1`] = `
 ]
 `;
 
+exports[`text (isCI = false) > tab completes the focused suggestion 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m  [2mSearch:[22m /tmp/foo/█
+[36m│[39m  [32m●[39m /tmp/foo/bar.txt
+[36m│[39m  [2m○[22m [2m/tmp/foo/baz.text[22m
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/b█",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/bar.txt█
+[36m│[39m  [32m●[39m /tmp/foo/bar.txt
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2m/tmp/foo/bar.txt[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = false) > tab completion can descend into directories 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m  [2mSearch:[22m /tmp/█
+[36m│[39m  [32m●[39m /tmp/bar
+[36m│[39m  [2m○[22m [2m/tmp/foo[22m
+[36m│[39m  [2m○[22m [2m/tmp/hello[22m
+[36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m /tmp/f█
+[36m│[39m  [32m●[39m /tmp/foo
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo█
+[36m│[39m  [32m●[39m /tmp/foo/bar.txt
+[36m│[39m  [2m○[22m [2m/tmp/foo/baz.text[22m
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/█",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/b█",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/bar.txt█
+[36m│[39m  [32m●[39m /tmp/foo/bar.txt
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2m/tmp/foo/bar.txt[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`text (isCI = false) > validation errors render and clear (using Error) 1`] = `
 [
   "<cursor.hide>",
@@ -212,14 +302,14 @@ exports[`text (isCI = false) > validation errors render and clear (using Error) 
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/r█
 [36m│[39m  [32m●[39m /tmp/root.zip
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -229,7 +319,7 @@ exports[`text (isCI = false) > validation errors render and clear (using Error) 
 [33m│[39m  [2mSearch:[22m /tmp/r█
 [33m│[39m  [33mshould be /tmp/bar[39m
 [33m│[39m  [32m●[39m /tmp/root.zip
-[33m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[33m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [33m└[39m",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
@@ -241,14 +331,14 @@ exports[`text (isCI = false) > validation errors render and clear (using Error) 
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [32m●[39m /tmp/root.zip
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/b█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -272,14 +362,14 @@ exports[`text (isCI = false) > validation errors render and clear 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/r█
 [36m│[39m  [32m●[39m /tmp/root.zip
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -289,7 +379,7 @@ exports[`text (isCI = false) > validation errors render and clear 1`] = `
 [33m│[39m  [2mSearch:[22m /tmp/r█
 [33m│[39m  [33mshould be /tmp/bar[39m
 [33m│[39m  [32m●[39m /tmp/root.zip
-[33m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[33m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [33m└[39m",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
@@ -301,14 +391,14 @@ exports[`text (isCI = false) > validation errors render and clear 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [32m●[39m /tmp/root.zip
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/b█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -332,7 +422,7 @@ exports[`text (isCI = true) > can cancel 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=1>",
@@ -356,14 +446,14 @@ exports[`text (isCI = true) > cannot submit unknown value 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/_█
 [36m│[39m  [33mNo matches found[39m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -373,7 +463,7 @@ exports[`text (isCI = true) > cannot submit unknown value 1`] = `
 [33m│[39m  [2mSearch:[22m /tmp/_█
 [33m│[39m  [33mNo matches found[39m
 [33m│[39m  [33mPlease select a path[39m
-[33m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[33m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [33m└[39m",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
@@ -385,14 +475,14 @@ exports[`text (isCI = true) > cannot submit unknown value 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/b█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -413,7 +503,7 @@ exports[`text (isCI = true) > initialValue sets the value 1`] = `
 [36m│[39m
 [36m│[39m  [2mSearch:[22m /tmp/bar█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -437,14 +527,14 @@ exports[`text (isCI = true) > renders cancelled value if one set 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/x█
 [36m│[39m  [33mNo matches found[39m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=3>",
@@ -473,7 +563,7 @@ exports[`text (isCI = true) > renders message 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=1>",
@@ -497,14 +587,14 @@ exports[`text (isCI = true) > renders submitted value 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/b█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=3>",
@@ -522,6 +612,96 @@ exports[`text (isCI = true) > renders submitted value 1`] = `
 ]
 `;
 
+exports[`text (isCI = true) > tab completes the focused suggestion 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m  [2mSearch:[22m /tmp/foo/█
+[36m│[39m  [32m●[39m /tmp/foo/bar.txt
+[36m│[39m  [2m○[22m [2m/tmp/foo/baz.text[22m
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/b█",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/bar.txt█
+[36m│[39m  [32m●[39m /tmp/foo/bar.txt
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2m/tmp/foo/bar.txt[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = true) > tab completion can descend into directories 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m  [2mSearch:[22m /tmp/█
+[36m│[39m  [32m●[39m /tmp/bar
+[36m│[39m  [2m○[22m [2m/tmp/foo[22m
+[36m│[39m  [2m○[22m [2m/tmp/hello[22m
+[36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=9>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m /tmp/f█
+[36m│[39m  [32m●[39m /tmp/foo
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo█
+[36m│[39m  [32m●[39m /tmp/foo/bar.txt
+[36m│[39m  [2m○[22m [2m/tmp/foo/baz.text[22m
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/█",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/b█",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m /tmp/foo/bar.txt█
+[36m│[39m  [32m●[39m /tmp/foo/bar.txt
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  foo
+[90m│[39m  [2m/tmp/foo/bar.txt[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`text (isCI = true) > validation errors render and clear (using Error) 1`] = `
 [
   "<cursor.hide>",
@@ -533,14 +713,14 @@ exports[`text (isCI = true) > validation errors render and clear (using Error) 1
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/r█
 [36m│[39m  [32m●[39m /tmp/root.zip
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -550,7 +730,7 @@ exports[`text (isCI = true) > validation errors render and clear (using Error) 1
 [33m│[39m  [2mSearch:[22m /tmp/r█
 [33m│[39m  [33mshould be /tmp/bar[39m
 [33m│[39m  [32m●[39m /tmp/root.zip
-[33m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[33m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [33m└[39m",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
@@ -562,14 +742,14 @@ exports[`text (isCI = true) > validation errors render and clear (using Error) 1
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [32m●[39m /tmp/root.zip
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/b█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -593,14 +773,14 @@ exports[`text (isCI = true) > validation errors render and clear 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/r█
 [36m│[39m  [32m●[39m /tmp/root.zip
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",
@@ -610,7 +790,7 @@ exports[`text (isCI = true) > validation errors render and clear 1`] = `
 [33m│[39m  [2mSearch:[22m /tmp/r█
 [33m│[39m  [33mshould be /tmp/bar[39m
 [33m│[39m  [32m●[39m /tmp/root.zip
-[33m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[33m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [33m└[39m",
   "<cursor.backward count=999><cursor.up count=7>",
   "<cursor.down count=1>",
@@ -622,14 +802,14 @@ exports[`text (isCI = true) > validation errors render and clear 1`] = `
 [36m│[39m  [2m○[22m [2m/tmp/foo[22m
 [36m│[39m  [2m○[22m [2m/tmp/hello[22m
 [36m│[39m  [32m●[39m /tmp/root.zip
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=9>",
   "<cursor.down count=3>",
   "<erase.down>",
   "[36m│[39m  [2mSearch:[22m /tmp/b█
 [36m│[39m  [32m●[39m /tmp/bar
-[36m│[39m  [2m↑/↓[22m to select • [2mEnter:[22m confirm • [2mType:[22m to search
+[36m│[39m  [2m↑/↓[22m to select • [2mTab:[22m complete • [2mEnter:[22m confirm • [2mType:[22m to search
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=6>",
   "<cursor.down count=1>",

--- a/packages/prompts/test/path.test.ts
+++ b/packages/prompts/test/path.test.ts
@@ -129,6 +129,45 @@ describe.each(['true', 'false'])('text (isCI = %s)', (isCI) => {
 		expect(output.buffer).toMatchSnapshot();
 	});
 
+	test('tab completes the focused suggestion', async () => {
+		const result = prompts.path({
+			message: 'foo',
+			root: '/tmp/foo/',
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'b', { name: 'b' });
+		input.emit('keypress', '\t', { name: 'tab' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toBe('/tmp/foo/bar.txt');
+		expect(output.buffer).toMatchSnapshot();
+	});
+
+	test('tab completion can descend into directories', async () => {
+		const result = prompts.path({
+			message: 'foo',
+			root: '/tmp/',
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'f', { name: 'f' });
+		input.emit('keypress', '\t', { name: 'tab' });
+		input.emit('keypress', '/', { name: '/' });
+		input.emit('keypress', 'b', { name: 'b' });
+		input.emit('keypress', '\t', { name: 'tab' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toBe('/tmp/foo/bar.txt');
+		expect(output.buffer).toMatchSnapshot();
+	});
+
 	test('initialValue sets the value', async () => {
 		const result = prompts.path({
 			message: 'foo',


### PR DESCRIPTION
## What does this PR do?

this implements pressing tab in the `path` prompt now fills the input with the focused suggestion. Typing `/` and tab again descends into directories, making deep paths quick to select.

possible follow-ups: add fuzzy/recursive matching below the root, and appending a trailing `/` when completing a directory.

related: #564
<!--
  Describe the change and why it's needed. Link to a related issue or discussion.
  If there is no issue, please explain why one isn't needed.
-->

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
